### PR TITLE
fix json dump error & resquest error

### DIFF
--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -236,6 +236,7 @@ class pcrclient(apiclient):
 
     async def room_start(self) -> RoomStartResponse:
         req = RoomStartRequest()
+        req.wac_auto_option_flag = 1
         return await self.request(req)
 
     async def borrow_dungeon_member(self, viewer_id):

--- a/autopcr/model/enums.py
+++ b/autopcr/model/enums.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import IntEnum as Enum
 
 class eInventoryType(Enum):
     TreasureBox = 0

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -21,12 +21,12 @@ class ClanInfoResponse(responses.ClanInfoResponse):
 class ClanLikeResponse(responses.ClanLikeResponse):
     def update(self, mgr: datamgr, request):
         mgr.stamina = self.stamina_info.user_stamina
-        mgr.clan_like_count = 0
+        mgr.clan_like_count = 1
 
 @handles
 class DungeonEnterAreaResponse(responses.DungeonEnterAreaResponse):
     def update(self, mgr: datamgr, request):
-        mgr.dungeon_area_id = self.quest_id / 1000
+        mgr.dungeon_area_id = self.quest_id // 1000
 
 @handles
 class DungeonResetResponse(responses.DungeonResetResponse):

--- a/autopcr/model/requests.py
+++ b/autopcr/model/requests.py
@@ -1585,6 +1585,7 @@ class PresentReceiveAllRequest(Request[PresentReceiveAllResponse]):
 	time_filter: int = None
 	type_filter: int = None
 	desc_flag: bool = None
+	is_exclude_stamina: bool = None
 	@property
 	def url(self) -> str:
 		return "present/receive_all"
@@ -1759,6 +1760,7 @@ class RaritySixQuestFinishRequest(Request[RaritySixQuestFinishResponse]):
 	def url(self) -> str:
 		return "rarity_6_quest/finish"
 class RoomStartRequest(Request[RoomStartResponse]):
+	wac_auto_option_flag: int = None
 	@property
 	def url(self) -> str:
 		return "room/start"
@@ -1862,7 +1864,7 @@ class RoomReceiveItemRequest(Request[RoomReceiveItemResponse]):
 class RoomReceiveItemAllRequest(Request[RoomReceiveItemAllResponse]):
 	@property
 	def url(self) -> str:
-		return "room/receive_item_all"
+		return "room/receive_all"
 class RoomMysetListRequest(Request[RoomMysetListResponse]):
 	@property
 	def url(self) -> str:
@@ -2287,6 +2289,12 @@ class AddUserTipsRequest(Request[AddUserTipsResponse]):
 	@property
 	def url(self) -> str:
 		return "tips/add_user_tips"
+class TowerTopRequest(Request[TowerTopResponse]):
+	is_first: int = None
+	return_cleared_ex_quest: int = None
+	@property
+	def url(self) -> str:
+		return "tower/top"
 class TowerBattleStartRequest(Request[TowerBattleStartResponse]):
 	quest_id: int = None
 	token: str = None

--- a/autopcr/model/responses.py
+++ b/autopcr/model/responses.py
@@ -762,7 +762,7 @@ class HatsuneSpecialBattleStartResponse(ResponseBase):
 	hit_treasure_nums: List[int] = None
 	hit_treasure_list: List[EventHitTreasureInfo] = None
 class HatsuneTopResponse(ResponseBase):
-	event_status: List[HatsuneEventStatus] = None
+	event_status: HatsuneEventStatus = None
 	additional_stories: List[HatsuneEventStoryState] = None
 	boss_ticket_info: InventoryInfo = None
 	event_decks: List[DeckData] = None

--- a/autopcr/module/modules.py
+++ b/autopcr/module/modules.py
@@ -8,7 +8,7 @@ import random
 @default(True)
 class clan_like(Module):
     async def do_task(self, client: pcrclient):
-        if not client.data.clan_like_count:
+        if client.data.clan_like_count == 1:
             raise ValueError('今日点赞次数已用完。')
         info = await client.get_clan_info()
         members = [x.viewer_id for x in info.members if x.viewer_id != client.viewer_id]


### PR DESCRIPTION
`enums.py`里是`Enum`类型在`json dumps`时（`req.log`）会提示不能序列化，需要指定类型（比如之前的`IntEnum`）
然后是其他的一些小问题的修复，其中`clan_like`是已点赞次数而不是未点赞次数（怎么`TowerTop`请求没了）