### PR TITLE
fix mana explore & auto hard sweep

### DIFF
--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -391,7 +391,7 @@ class pcrclient(apiclient):
                 if self.keys.get('buy_stamina_passive', 0) > self.data.recover_stamina_exec_count:
                     await self.recover_stamina()
                 else:
-                    raise SkipError(f"任务{name}体力不足")
+                    raise AbortError(f"任务{name}体力不足")
             if db.is_shiori_quest(quest):
                 event = db.quest_to_event_id[quest]
                 return await self.shiori_quest_skip(event, quest, times)

--- a/autopcr/module/modules.py
+++ b/autopcr/module/modules.py
@@ -858,6 +858,8 @@ class explore_exp(Module):
         msg: str = ""
         if exp_quest_remain:
             quest_id = client.data.get_max_avaliable_quest_exp()
+            if not quest_id:
+                raise AbortError("不存在可扫荡的exp探索")
             name = db.quest_name[quest_id]
             await client.training_quest_skip(quest_id, exp_quest_remain)
             msg = f"{name}扫荡{exp_quest_remain}次"
@@ -875,8 +877,10 @@ class explore_mana(Module):
         result: List[str] = []
         if gold_quest_remain:
             quest_id = client.data.get_max_avaliable_quest_mana()
+            if not quest_id:
+                raise AbortError("不存在可扫荡的mana探索")
             name = db.quest_name[quest_id]
-            await client.training_quest_skip(21001011, gold_quest_remain)
+            await client.training_quest_skip(quest_id, gold_quest_remain)
             result.append(f"{name}扫荡{gold_quest_remain}次")
         else:
             raise SkipError("mana已扫荡")

--- a/autopcr/module/modules.py
+++ b/autopcr/module/modules.py
@@ -7,8 +7,7 @@ from ..model.error import *
 from ..core.database import db
 from ..model.models import *
 import random
-import itertools
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 
 @enumtype([x for x in range(-1, 24)])
 @default(-1)
@@ -28,6 +27,43 @@ class cron3(cron): ...
 @description('定时清日常4')
 class cron4(cron): ...
 
+@description('智能刷hard图')
+@booltype
+@default(False)
+class smart_hard_sweep(Module):
+    async def do_task(self, client: pcrclient):
+        need_list, _ = client.data.get_need_memory()
+        need_list = [(token, need - client.data.get_inventory(token)) for token, need in need_list if need > client.data.get_inventory(token)]
+
+        if not need_list:
+            raise SkipError("不存在缺乏的记忆碎片")
+
+        need_list = sorted(need_list, key=lambda x: x[1])
+        stop = False
+        for token, _ in need_list:
+            if token[1] not in db.memory_quest:
+                continue
+            tmp = []
+            for quest_id in db.memory_quest[token[1]]:
+                max_times = 5 if db.is_shiori_quest(quest_id) else 3
+                try:
+                    resp = await client.quest_skip_aware(quest_id, max_times)
+                    tmp += resp
+                except SkipError:
+                    pass
+                except AbortError as e:
+                    stop = True
+                    if str(e).endswith("体力不足"):
+                        if not tmp and not self.log: self._log(str(e))
+                    else:
+                        if tmp: self._log(await client.serlize_reward(tmp, token))
+                        raise e
+                    break
+            if tmp:
+                self._log(await client.serlize_reward(tmp, token))
+            if stop:
+                break
+
 @description('赛马')
 @booltype
 @default(True)
@@ -38,15 +74,13 @@ class chara_fortune(Module):
         if client.data.cf is None:
             raise SkipError("今日已赛马")
         res = await client.draw_chara_fortune()
-        result = f"赛马第{client.data.cf.rank}名，获得了宝石x{res.reward_list[0].received}" 
-        return result
+        self._log(f"赛马第{client.data.cf.rank}名，获得了宝石x{res.reward_list[0].received}")
 
 @description('喂蛋糕')
 @booltype
 @default(True)
 class love_up(Module):
     async def do_task(self, client: pcrclient):
-        result = []
         for unit in client.data.unit_love.values():
             unit_id = unit.chara_id * 100 + 1
             unit_name = db.get_inventory_name_san((eInventoryType.Unit, unit_id))
@@ -66,15 +100,13 @@ class love_up(Module):
                     if dis <= 0: 
                         break
                 if dis > 0:
-                    result.append(f"{unit_name}: 蛋糕数量不足")
+                    self._log(f"{unit_name}: 蛋糕数量不足")
                     break
                 await client.multi_give_gift(unit_id, cakes)
-                result.append(f"{unit_name}: 亲密度升至{love_level}级")
+                self._log(f"{unit_name}: 亲密度升至{love_level}级")
 
-        if len(result) == 0:
+        if not self.log:
             raise SkipError("所有角色均已亲密度满级")
-        msg = '\n'.join(result)
-        return msg
 
 @description('免费十连')
 @booltype
@@ -112,11 +144,9 @@ class free_gacha(Module):
             new_unit += [item for item in resp.reward_info_list if item.type == eInventoryType.Unit]
             reward_list += [item for item in resp.reward_info_list if item.type != eInventoryType.Unit]
             # bonues reward TODO
-        result = ""
-        if len(new_unit) != 0:
-            result += f"NEW: \n" + '\n'.join([db.get_inventory_name(item) for item in new_unit]) + '\n'
-        result += await client.serlize_reward(reward_list)
-        return result
+        if new_unit:
+            self._log(f"NEW: \n" + '\n'.join([db.get_inventory_name(item) for item in new_unit]) + '\n')
+        self._log(await client.serlize_reward(reward_list))
 
 @description('商店购买最大经验药水量')
 @enumtype([0, 1000, 5000, 20000, 50000, 99999])
@@ -306,8 +336,8 @@ class mission_receive_first(Module):
             if db.is_daily_mission(mission.mission_id) and mission.mission_status == eMissionStatusType.EnableReceive:
                 resp = await client.mission_receive()
                 reward = await client.serlize_reward(resp.rewards)
-                msg = "领取了任务奖励，获得了:\n" + reward
-                return msg
+                self._log("领取了任务奖励，获得了:\n" + reward)
+                return
         raise SkipError("没有可领取的任务奖励")
 
 @description('结束时领取任务奖励')
@@ -320,8 +350,8 @@ class mission_receive_last(Module):
             if db.is_daily_mission(mission.mission_id) and mission.mission_status == eMissionStatusType.EnableReceive:
                 resp = await client.mission_receive()
                 reward = await client.serlize_reward(resp.rewards)
-                msg = "领取了任务奖励，获得了:\n" + reward
-                return msg
+                self._log("领取了任务奖励，获得了:\n" + reward)
+                return
         raise SkipError("没有可领取的任务奖励")
 
 @description('六星碎片')
@@ -329,10 +359,7 @@ class mission_receive_last(Module):
 @default(3)
 class six_star(Module):
     async def do_task(self, client: pcrclient):
-        result: List[str] = []
         is_skip = True
-        is_error = False
-        is_abort = False
         times = self.value
         for quest_id, (pure_memory, unit_id) in db.six_area.items():
             data = client.data.unit[unit_id]
@@ -345,27 +372,19 @@ class six_star(Module):
                     rewards = await client.quest_skip_aware(quest_id, times, True, True)
                     msg = await client.serlize_reward(rewards, (eInventoryType.Item, pure_memory))
                     is_skip = False
-                    result.append(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {msg}")
+                    self._log(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {msg}")
                 except SkipError as e:
-                    result.append(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {str(e)}")
+                    self._log(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {str(e)}")
                 except AbortError as e:
-                    is_abort = True
-                    result.append(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {str(e)}")
-                    break
+                    raise AbortError(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {str(e)}")
                 except Exception as e:
-                    is_error = True
-                    result.append(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {str(e)}")
-                    break
+                    raise ValueError(f"{db.inventory_name[(eInventoryType.Unit, unit_id)]}六星本: {str(e)}")
             else:
                 pass
                 # result.append(f"{quest_id}: 材料已够，无需刷取")
-        msg = '\n'.join(result)
-        if is_error: raise ValueError(msg)
-        if is_abort: raise AbortError(msg)
-        if is_skip: raise SkipError(msg)
-        if len(result) == 0:
+        if is_skip: raise SkipError("")
+        if not self.log:
             raise SkipError("六星碎片均已足够，无需刷取")
-        return msg
 
 @description('最高级地下城扫荡')
 @booltype
@@ -388,8 +407,7 @@ class underground_skip(Module):
                 #     rewards += reward.reward_list
                 # result = await client.serlize_reward(rewards)
                 dungeon_name = db.dungeon_name[id]
-                msg = f"扫荡了【{dungeon_name}】"
-                return msg
+                self._log(f"扫荡了【{dungeon_name}】")
                 # self.set_result(f"扫荡了{dungeon_name}，获得了：\n{result}")
             else:
                 raise AbortError("不存在已完成讨伐的地下城")
@@ -402,8 +420,7 @@ class underground_skip(Module):
 class user_info(Module):
     async def do_task(self, client: pcrclient):
         now = datetime.datetime.now().strftime("%Y-%m-%d, %H:%M:%S")
-        msg = f"{client.data.name} 体力{client.data.stamina}({db.team_max_stamina[client.data.team_level]}) 等级{client.data.team_level} 钻石{client.data.jewel.free_jewel} mana{client.data.gold.gold_id_free} 扫荡券{client.data.get_inventory((eInventoryType.Item, 23001))} 母猪石{client.data.get_inventory((eInventoryType.Item, 90005))}\n清日常时间:{now}"
-        return msg
+        self._log(f"{client.data.name} 体力{client.data.stamina}({db.team_max_stamina[client.data.team_level]}) 等级{client.data.team_level} 钻石{client.data.jewel.free_jewel} mana{client.data.gold.gold_id_free} 扫荡券{client.data.get_inventory((eInventoryType.Item, 23001))} 母猪石{client.data.get_inventory((eInventoryType.Item, 90005))}\n清日常时间:{now}")
 
 @description('阅读角色剧情')
 @enumtype(["none", "除ue普妈圣千普千真步", "all"])
@@ -413,7 +430,6 @@ class unit_story_reading(Module):
         ignore = True if self.value != "all" else False
         read_story = set(client.data.read_story_ids)
         read_story.add(0) # no pre story
-        result = []
         ignore_chara_id = set([
             1002, # ue
             1010, # 真步
@@ -426,13 +442,13 @@ class unit_story_reading(Module):
                 continue
             if story_id not in read_story and pre_story_id in read_story and chara_id in client.data.unit_love and client.data.unit_love[chara_id].love_level >= love_level:
                 await client.read_story(story_id)
-                result.append(title)
                 read_story.add(story_id)
-        if len(result) == 0:
+                self._log(f"阅读了{title}")
+
+        if not self.log:
             raise SkipError("不存在未阅读的角色剧情")
         client.data.read_story_ids = list(read_story)
-        msg = f"阅读了{len(result)}篇：" + '|'.join(result) 
-        return msg
+        self._log(f"共{len(self.log)}篇")
 
 @description('阅读主线剧情')
 @booltype
@@ -441,26 +457,18 @@ class main_story_reading(Module):
     async def do_task(self, client: pcrclient):
         read_story = set(client.data.read_story_ids)
         read_story.add(0) # no pre story
-        result = []
-        msg = ""
         for story_id, pre_story_id, unlock_quest_id, title in db.main_story:
             if story_id not in read_story and pre_story_id in read_story:
                 if not await client.unlock_quest_id(unlock_quest_id):
-                    msg = f"区域{str(unlock_quest_id)}未通关，无法观看{title}\n"
-                    break
+                    raise AbortError(f"区域{str(unlock_quest_id)}未通关，无法观看{title}\n")
                 await client.read_story(story_id)
-                result.append(title)
                 read_story.add(story_id)
+                self._log(f"阅读了{title}")
+
         client.data.read_story_ids = list(read_story)
-        if msg != "":
-            if len(result) != 0:
-                raise AbortError("已阅读" + '|'.join(result) + "，但" + msg)
-            else:
-                raise AbortError(msg)
-        if len(result) == 0:
+        if not self.log:
             raise SkipError("不存在未阅读的主线剧情")
-        msg = f"阅读了{len(result)}篇：" + '|'.join(result) 
-        return msg
+        self._log(f"共{len(self.log)}篇")
 
 @description('阅读露娜塔剧情')
 @booltype
@@ -469,8 +477,6 @@ class tower_story_reading(Module):
     async def do_task(self, client: pcrclient):
         read_story = set(client.data.read_story_ids)
         read_story.add(0) # no pre story
-        result = []
-        msg = ""
         for story_id, pre_story_id, unlock_quest_id, title, start_time in db.tower_story:
             now = datetime.datetime.now()
             start_time = db.parse_time(start_time)
@@ -478,48 +484,40 @@ class tower_story_reading(Module):
                 continue
             if story_id not in read_story and pre_story_id in read_story:
                 if not await client.unlock_quest_id(unlock_quest_id):
-                    msg = f"层数{db.tower2floor[unlock_quest_id]}未通关，无法观看{title}\n"
-                    break
+                    raise AbortError(f"层数{db.tower2floor[unlock_quest_id]}未通关，无法观看{title}\n")
                 await client.read_story(story_id)
-                result.append(title)
                 read_story.add(story_id)
+                self._log(f"阅读了{title}")
+
         client.data.read_story_ids = list(read_story)
-        if msg != "":
-            if len(result) != 0:
-                raise AbortError("已阅读" + '|'.join(result) + "，但" + msg)
-            else:
-                raise AbortError(msg)
-        if len(result) == 0:
+        if not self.log:
             raise SkipError("不存在未阅读的露娜塔剧情")
-        msg = f"阅读了{len(result)}篇：" + '|'.join(result) 
-        return msg
+        self._log(f"共{len(self.log)}篇")
 
 @description('阅读活动剧情')
 @booltype
 @default(True)
 class hatsune_story_reading(Module):
     async def do_task(self, client: pcrclient):
-        result = []
         read_story = set(client.data.read_story_ids)
         read_story.add(0) # no pre story
         unlock_story = set(client.data.unlock_story_ids)
         for story_id, pre_story_id, title in db.event_story:
             if story_id not in read_story and pre_story_id in read_story and story_id in unlock_story:
                 await client.read_story(story_id)
-                result.append(title)
                 read_story.add(story_id)
-        if len(result) == 0:
+                self._log(f"阅读了{title}")
+
+        if not self.log:
             raise SkipError("不存在未阅读的活动剧情")
         client.data.read_story_ids = list(read_story)
-        msg = f"阅读了{len(result)}篇：" + '|'.join(result) 
-        return msg
+        self._log(f"共{len(self.log)}篇")
 
 @description('阅读活动信赖度')
 @booltype
 @default(True)
 class hatsune_dear_reading(Module):
     async def do_task(self, client: pcrclient):
-        result = []
         event_active = False
         for event in client.data.event_statuses:
             if event.event_type != 1 or event.period != 2:
@@ -531,14 +529,14 @@ class hatsune_dear_reading(Module):
             resp = (await client.get_hatsune_dear_top(event.event_id))
             for story in resp.unlock_dear_story_info_list:
                 if not story.is_choiced:
-                    result.append(f"{story.story_id}")
                     await client.read_dear(event.event_id, story.story_id)
+                    self._log(f"阅读了{story.story_id}")
+
         if not event_active:
             raise SkipError("当前无进行中的活动")
-        if len(result) == 0:
+        if not self.log:
             raise SkipError("不存在未阅读的活动信赖度剧情")
-        msg = "阅读了" + ' '.join(result) 
-        return msg
+        self._log(f"共{len(self.log)}篇")
 
 @description('讨伐证交换')
 @enumtype(["none", "前两轮重置", "all"])
@@ -547,7 +545,7 @@ class hatsune_gacha_exchange(Module):
     async def do_task(self, client: pcrclient):
         early_stop = False if self.value == "all" else True
         event_active = False
-        result = []
+
         for event in client.data.event_statuses:
             if event.event_type != 1 or event.period != 2:
                 continue
@@ -559,29 +557,31 @@ class hatsune_gacha_exchange(Module):
             ticket = client.data.get_inventory((eInventoryType.Item, exchange_ticket_id))
             while(True):
                 if ticket == 0:
+                    self._log(f"{event.event_id}: 无讨伐证，停止交换")
                     break
                 if res.event_gacha_info.gacha_step >= 6:
                     exchange_times = min(client.data.settings.loop_box_multi_gacha_count, ticket)
+                    self._log(f"{event.event_id}: 当前处于第{res.event_gacha_info.gacha_step}轮，一键交换{exchange_times}次")
                     await client.exec_hatsune_gacha(event.event_id, event.event_id, exchange_times, ticket, 1)
                     ticket -= exchange_times
                 else:
                     target_done = len([item.reward_id for item in box_item.values() if item.reset_target and item.remain_inbox_count]) == 0
                     remain_cnt = sum(item.remain_inbox_count for item in box_item.values())
                     if remain_cnt == 0 or (target_done and res.event_gacha_info.gacha_step <= 2 and early_stop):
+                        self._log(f"{event.event_id}: 已达成重置条件，重置交换轮数")
                         res = await client.reset_hatsune_gacha(event.event_id, event.event_id)
                         box_item = {item.box_set_id: item for item in res.event_gacha_info.box_set_list}
                         continue
                     exchange_times = min(100, ticket, remain_cnt)
+                    self._log(f"{event.event_id}: 当前处于第{res.event_gacha_info.gacha_step}轮，交换{exchange_times}次")
                     resp = await client.exec_hatsune_gacha(event.event_id, event.event_id, exchange_times, ticket, 0)
                     ticket -= exchange_times
                     for item in resp.draw_result:
                         box_item[item.box_set_id].remain_inbox_count -= item.hit_reward_count
-            result.append(f"{event.event_id}: 已交换至第{res.event_gacha_info.gacha_step}轮")
+            self._log(f"{event.event_id}: 已交换至第{res.event_gacha_info.gacha_step}轮")
             
         if not event_active:
             raise SkipError("当前无进行中的活动")
-        msg = '\n'.join(result)
-        return msg
 
 @description('在公会中自动随机选择一位成员点赞。')
 @booltype
@@ -595,15 +595,13 @@ class clan_like(Module):
         if len(members) == 0: raise AbortError("No other members in clan")
         rnd = random.choice(members)
         await client.clan_like(rnd[0])
-        msg = f"为【{rnd[1]}】点赞"
-        return msg
+        self._log(f"为【{rnd[1]}】点赞")
 
 @description('活动h本')
 @enumtype(["none", "odd", "even", "all"])
 @default("none")
 class hatsune_h_sweep(Module):
     async def do_task(self, client: pcrclient):
-        result: List[str] = []
         area = []
         hard = 200
         is_error = False
@@ -628,30 +626,27 @@ class hatsune_h_sweep(Module):
                     times = 3 - client.data.hatsune_quest_dict[event.event_id][quest_id].daily_clear_count
                     await client.quest_skip_aware(quest_id, 3, False, True)
                     is_skip = False
-                    result.append(f"{quest_id}: 扫荡{times}次")
+                    self._log(f"{quest_id}: 扫荡{times}次")
                 except SkipError as e:
-                    result.append(f"{quest_id}: {str(e)}")
+                    self._log(f"{quest_id}: {str(e)}")
                 except AbortError as e:
                     is_abort = True
-                    result.append(f"{quest_id}: {str(e)}")
+                    self._log(f"{quest_id}: {str(e)}")
                     break
                 except Exception as e: 
                     is_error = True
-                    result.append(f"{quest_id}: {str(e)}")
+                    self._log(f"{quest_id}: {str(e)}")
                     break
         if not event_active: raise SkipError("当前无进行中的活动")
-        msg = '\n'.join(result)
-        if is_error: raise ValueError(msg)
-        if is_abort: raise AbortError(msg)
-        if is_skip: raise SkipError(msg)
-        return msg
+        if is_error: raise ValueError("")
+        if is_abort: raise AbortError("")
+        if is_skip: raise SkipError("")
 
 @description('领取活动任务奖励')
 @booltype
 @default(True)
 class hatsune_mission_accept(Module):
     async def do_task(self, client: pcrclient):
-        result: List[str] = []
         is_error = False
         is_abort = False
         is_skip = True
@@ -671,29 +666,26 @@ class hatsune_mission_accept(Module):
                     for type in types:
                         res = await client.hatsune_mission_receive(event.event_id, type)
                         reward = await client.serlize_reward(res.rewards)
-                        result.append(f"{event.event_id}: 领取了任务奖励，获得了:\n" + reward)
+                        self._log(f"{event.event_id}: 领取了任务奖励，获得了:\n" + reward)
             except SkipError as e:
-                result.append(f"{event.event_id}: {str(e)}")
+                self._log(f"{event.event_id}: {str(e)}")
             except AbortError as e:
                 is_abort = True
-                result.append(f"{event.event_id}: {str(e)}")
+                self._log(f"{event.event_id}: {str(e)}")
             except Exception as e:
                 is_error = True
-                result.append(f"{event.event_id}: {str(e)}")
+                self._log(f"{event.event_id}: {str(e)}")
 
         if not event_active: raise SkipError("当前无进行中的活动")
-        msg = '\n'.join(result)
-        if is_error: raise ValueError(msg)
-        if is_abort: raise AbortError(msg)
-        if is_skip: raise SkipError(msg)
-        return msg
+        if is_error: raise ValueError("")
+        if is_abort: raise AbortError("")
+        if is_skip: raise SkipError("")
 
 @description('活动h本boss')
 @enumtype(["none", "max", "max - 1"])
 @default("none")
 class hatsune_hboss_sweep(Module):
     async def do_task(self, client: pcrclient):
-        result: List[str] = []
         is_error = False
         is_abort = False
         is_skip = True
@@ -719,22 +711,19 @@ class hatsune_hboss_sweep(Module):
                     raise SkipError(f"boss券不足 {ticket}")
                 resp = await client.hatsune_boss_skip(event.event_id, boss_id, times, ticket)
                 is_skip = False
-                result.append(f"{event.event_id} h boss: 扫荡{times}次")
+                self._log(f"{event.event_id} h boss: 扫荡{times}次")
             except SkipError as e:
-                result.append(f"{event.event_id}: {str(e)}")
+                self._log(f"{event.event_id}: {str(e)}")
             except AbortError as e:
                 is_abort = True
-                result.append(f"{event.event_id}: {str(e)}")
+                self._log(f"{event.event_id}: {str(e)}")
             except Exception as e: 
                 is_error = True
-                result.append(f"{event.event_id}: {str(e)}")
-        if not event_active:
-            raise SkipError("当前无进行中的活动")
-        msg = '\n'.join(result)
-        if is_error: raise ValueError(msg)
-        if is_abort: raise AbortError(msg)
-        if is_skip: raise SkipError(msg)
-        return msg
+                self._log(f"{event.event_id}: {str(e)}")
+        if not event_active: raise SkipError("当前无进行中的活动")
+        if is_error: raise ValueError("")
+        if is_abort: raise AbortError("")
+        if is_skip: raise SkipError("")
 
 @description('使用体力时，若体力不足，最多允许购买的体力管数。')
 @enumtype([0, 1, 2, 3, 6, 9, 12])
@@ -756,8 +745,7 @@ class buy_stamina_active(Module):
                 raise AbortError('体力恢复将超过999。中止购买体力')
             await client.recover_stamina()
             cnt += 1
-        msg = f"购买了{str(cnt)}次体力"
-        return msg
+        self._log(f"购买了{str(cnt)}次体力")
 
 @description('收取家园体')
 @booltype
@@ -765,13 +753,12 @@ class buy_stamina_active(Module):
 class room_accept_all(Module):
     async def do_task(self, client: pcrclient):
         room = await client.room_start()
-        t = client.data.stamina
         for x in room.user_room_item_list:
             if x.item_count:
                 res = await client.room_accept_all()
                 msg = await client.serlize_reward(res.reward_list)
-                self._log(f'收取家园体力：{t} => {client.data.stamina}')
-                return msg
+                self._log(msg)
+                return
         raise SkipError('没有可收取的家园物品。')
 
 @description('升级家园家具')
@@ -787,16 +774,13 @@ class room_upper_all(Module):
             for item in layout.floor:
                 floors[item.serial_id] = cnt
 
-        result = []
         for x in room.user_room_item_list:
             if db.is_room_item_level_upable(client.data.team_level, x):
                 await client.room_level_up_item(floors[x.serial_id], x)
-                result.append(f"开始升级{db.get_inventory_name_san((eInventoryType.RoomItem, x.room_item_id))}至{x.room_item_level + 1}级")
+                self._log(f"开始升级{db.get_inventory_name_san((eInventoryType.RoomItem, x.room_item_id))}至{x.room_item_level + 1}级")
 
-        if len(result) == 0:
+        if not self.log:
             raise SkipError('没有可升级的家园物品。')
-        msg = '\n'.join(result)
-        return msg
 
 @description('公会小屋点赞，先回赞，再随机点赞')
 @booltype
@@ -825,8 +809,7 @@ class room_like_back(Module):
             cnt += 1
 
         result = await client.serlize_reward(result)
-        msg = f"为【{'|'.join(like_user)}】点赞，获得了:\n" + result
-        return msg
+        self._log(f"为【{'|'.join(like_user)}】点赞，获得了:\n" + result)
 
 @description('普通扭蛋')
 @booltype
@@ -846,7 +829,7 @@ class normal_gacha(Module):
         msg = "10件装备"
         if memory:
             msg = await client.serlize_reward(memory) + f"\n{10 - len(memory)}件装备"
-        return msg
+        self._log(msg)
 
 @description('EXP探索')
 @booltype
@@ -855,17 +838,15 @@ class explore_exp(Module):
     async def do_task(self, client: pcrclient):
         # 11级探索
         exp_quest_remain = client.data.training_quest_max_count.exp_quest - client.data.training_quest_count.exp_quest
-        msg: str = ""
         if exp_quest_remain:
             quest_id = client.data.get_max_avaliable_quest_exp()
             if not quest_id:
                 raise AbortError("不存在可扫荡的exp探索")
             name = db.quest_name[quest_id]
             await client.training_quest_skip(quest_id, exp_quest_remain)
-            msg = f"{name}扫荡{exp_quest_remain}次"
+            self._log(f"{name}扫荡{exp_quest_remain}次")
         else:
             raise SkipError("exp已扫荡")
-        return msg
 
 @description('MANA探索')
 @booltype
@@ -874,18 +855,15 @@ class explore_mana(Module):
     async def do_task(self, client: pcrclient):
         # 11级探索
         gold_quest_remain = client.data.training_quest_max_count.gold_quest - client.data.training_quest_count.gold_quest
-        result: List[str] = []
         if gold_quest_remain:
             quest_id = client.data.get_max_avaliable_quest_mana()
             if not quest_id:
                 raise AbortError("不存在可扫荡的mana探索")
             name = db.quest_name[quest_id]
             await client.training_quest_skip(quest_id, gold_quest_remain)
-            result.append(f"{name}扫荡{gold_quest_remain}次")
+            self._log(f"{name}扫荡{gold_quest_remain}次")
         else:
             raise SkipError("mana已扫荡")
-        msg = ' '.join(result)
-        return msg
 
 @description('露娜塔回廊扫荡')
 @booltype
@@ -911,8 +889,7 @@ class tower_cloister_sweep(Module):
             for rewards in res.quest_result_list:
                 result.extend(rewards.reward_list)
             result = await client.serlize_reward(result, db.xinsui)
-            msg = f"扫荡了{times}次，获得了:\n" + result
-            return msg
+            self._log(f"扫荡了{times}次，获得了:\n" + result)
         else:
             raise SkipError("回廊已扫荡")
 
@@ -934,7 +911,8 @@ class present_receive(Module):
         while True:
             present = await client.present_index()
             for present in present.present_info_list:
-                if not (present.reward_type == eInventoryType.Stamina and present.reward_id == 93001):
+                if not is_exclude_stamina or not (present.reward_type == eInventoryType.Stamina and present.reward_id == 93001):
+                    print(present.reward_type, present.reward_id)
                     res = await client.present_receive_all(is_exclude_stamina)
                     result += res.rewards
                     received = True
@@ -945,8 +923,7 @@ class present_receive(Module):
         if not received:
             raise SkipError(f"不存在未领取{'的非体力的' if is_exclude_stamina == True else '的'}礼物")
         msg = await client.serlize_reward(result)
-        self._log('礼物已领取完成')
-        return op + msg
+        self._log(op + msg)
 
 @description('领取双场币')
 @booltype
@@ -954,16 +931,13 @@ class present_receive(Module):
 class jjc_reward(Module):
     async def do_task(self, client: pcrclient):
         info = await client.get_arena_info()
-        result: List[str] = []
         if info.reward_info.count:
             await client.receive_arena_reward()
-        result.append(f"jjc币x{info.reward_info.count}")
+        self._log(f"jjc币x{info.reward_info.count}")
         info = await client.get_grand_arena_info()
         if info.reward_info.count:
             await client.receive_grand_arena_reward()
-        result.append(f"pjjc币x{info.reward_info.count}")
-        msg = ' '.join(result)
-        return msg
+        self._log(f"pjjc币x{info.reward_info.count}")
 
 @description('刷取心碎3')
 @booltype
@@ -972,8 +946,7 @@ class xinsui3_sweep(Module):
     async def do_task(self, client: pcrclient):
         result = await client.quest_skip_aware(18001003, 5)
         msg = await client.serlize_reward(result, db.xinsui)
-        self._log('心碎3已刷取完成')
-        return msg
+        self._log(msg)
 
 @description('刷取心碎2')
 @booltype
@@ -982,8 +955,7 @@ class xinsui2_sweep(Module):
     async def do_task(self, client: pcrclient):
         result = await client.quest_skip_aware(18001002, 5)
         msg = await client.serlize_reward(result, db.xinsui)
-        self._log('心碎2已刷取完成')
-        return msg
+        self._log(msg)
 
 @description('刷取心碎1')
 @booltype
@@ -992,8 +964,7 @@ class xinsui1_sweep(Module):
     async def do_task(self, client: pcrclient):
         result = await client.quest_skip_aware(18001001, 5)
         msg = await client.serlize_reward(result, db.xinsui)
-        self._log('心碎1已刷取完成')
-        return msg
+        self._log(msg)
 
 @description('刷取星球杯2')
 @booltype
@@ -1002,8 +973,7 @@ class xingqiubei2_sweep(Module):
     async def do_task(self, client: pcrclient):
         result = await client.quest_skip_aware(19001002, 5)
         msg = await client.serlize_reward(result, db.xingqiubei)
-        self._log('星球杯2已刷取完成')
-        return msg
+        self._log(msg)
 
 @description('刷取星球杯1')
 @booltype
@@ -1012,8 +982,7 @@ class xingqiubei1_sweep(Module):
     async def do_task(self, client: pcrclient):
         result = await client.quest_skip_aware(19001001, 5)
         msg = await client.serlize_reward(result, db.xingqiubei)
-        self._log('星球杯1已刷取完成')
-        return msg
+        self._log(msg)
 
 @description('''
 首先按次数逐一刷取名字为start的图
@@ -1043,24 +1012,19 @@ class smart_sweep(Module):
                     if not have_normal:
                         raise AbortError("no normal, stop")
 
-        msg = []
         result = []
         if nloop == [] and loop == []:
             raise AbortError("未找到start和loop")
-        for quest_id, count in _sweep(): # loop 全是hard very hard时会死循环
+        for quest_id, count in _sweep(): 
             try:
                 result += await client.quest_skip_aware(quest_id, count, True, True)
             except SkipError as e:
-                m = str(e)
-                if m.endswith('体力不足'): 
-                    break
+                pass
             except AbortError as e:
-                m = str(e)
-                msg.append(m)
+                self._log(str(e))
                 break
         
-        msg = '\n'.join(msg) + await client.serlize_reward(result)
-        return msg
+        self._log(await client.serlize_reward(result))
 
 '''
 class shop_buy(Module):
@@ -1149,7 +1113,7 @@ class new_daily_shop(Module):
 @default('none')
 class all_in_hatsune(Module):
     async def do_task(self, client: pcrclient):
-        quest = event_id = 0
+        quest = 0
         for event in client.data.event_statuses: # 复刻和正常一起开的话会刷哪个？
             if event.event_type != 1 or event.period != 2:
                 continue
@@ -1159,7 +1123,6 @@ class all_in_hatsune(Module):
                 quest = 1000 * event.event_id + 110
             elif self.value == 'n-15':
                 quest = 1000 * event.event_id + 115
-            event_id = event.event_id
             
             break
         
@@ -1167,10 +1130,9 @@ class all_in_hatsune(Module):
         
         count = client.data.stamina // db.quest_info[quest][1]
 
-        if count == 0: raise SkipError("体力不足")
+        if count == 0: raise AbortError("体力不足")
         await client.quest_skip_aware(quest, count)
         self._log(f"已刷{quest}图{count}次")
-        return "已刷{quest}图{count}次"
 
 def register_test():
     ModuleManager._modules = [
@@ -1207,6 +1169,7 @@ def register_all():
         hatsune_gacha_exchange,
         hatsune_mission_accept,
         smart_sweep,
+        smart_hard_sweep,
 
         buy_stamina_active,
         all_in_hatsune,

--- a/autopcr/util/sqlite3.py
+++ b/autopcr/util/sqlite3.py
@@ -112,6 +112,13 @@ class RecordDAO:
             ).fetchall()
         return r
 
+    def get_unit_memory(self):
+        with self.connect() as conn:
+            r = conn.execute(
+                f"SELECT unit_id, unit_material_id FROM unit_rarity WHERE unit_id < 190000 GROUP BY unit_material_id"
+            ).fetchall()
+        return r
+
     def get_unlock_rarity_six(self):
         with self.connect() as conn:
             r = conn.execute(
@@ -119,10 +126,21 @@ class RecordDAO:
             ).fetchall()
         return r
 
+    def get_memory_quest_data(self):
+        with self.connect() as conn:
+            r = conn.execute(
+                f"SELECT quest_id, reward_image_1 FROM quest_data WHERE quest_id>=12000000 and quest_id<13000000",
+            ).fetchall()
+            # shiori wait for stamina half and odd up
+            # r += conn.execute(
+            #     f"SELECT quest_id, drop_reward_id FROM shiori_quest WHERE drop_reward_id != 0",
+            # ).fetchall()
+        return r
+
     def get_six_area_data(self):
         with self.connect() as conn:
             r = conn.execute(
-                f"SELECT quest_id, reward_image_1 FROM quest_data WHERE quest_id>13018000 and quest_id<13999999",
+                f"SELECT quest_id, reward_image_1 FROM quest_data WHERE quest_id>=13000000 and quest_id<14000000",
             ).fetchall()
         return r
 
@@ -221,3 +239,38 @@ class RecordDAO:
             ).fetchall()
         return r
 
+    def get_unit_rarity_consume(self):
+        with self.connect() as conn:
+            r = conn.execute(
+                f"SELECT unit_id, rarity, unit_material_id, consume_num FROM unit_rarity",
+            ).fetchall()
+            r += conn.execute(
+                f"SELECT unit_id, 6, material_id, material_count FROM unlock_rarity_6 WHERE material_id!=25001",
+            ).fetchall()
+            r += conn.execute(
+                f"SELECT unit_id, 6, material_id, SUM(material_count) FROM unlock_rarity_6 WHERE material_id=25001 GROUP BY unit_id",
+            ).fetchall()
+        return r
+
+    def get_unit_unique_equip_id(self):
+        with self.connect() as conn:
+            r = conn.execute(
+                f"SELECT unit_id, equip_id FROM unit_unique_equip",
+            ).fetchall()
+        return r
+
+    def get_unique_equip_consume(self):
+        with self.connect() as conn:
+            r = conn.execute(
+                f"SELECT equip_id, 0, reward_type_1, item_id_1, consume_num_1, reward_type_2, item_id_2, consume_num_2 FROM unique_equipment_craft",
+            ).fetchall()
+            r += conn.execute(
+                f"SELECT equip_id, 0, reward_type_2, item_id_2, consume_num_2 FROM unique_equipment_craft",
+            ).fetchall()
+            r += conn.execute(
+                f"SELECT equip_id, unique_equip_rank, reward_type_1, item_id_1, consume_num_1, reward_type_2, item_id_2, consume_num_2 FROM unique_equipment_rankup",
+            ).fetchall()
+            r += conn.execute(
+                f"SELECT equip_id, unique_equip_rank, reward_type_2, item_id_2, consume_num_2 FROM unique_equipment_rankup",
+            ).fetchall()
+        return r

--- a/task.py
+++ b/task.py
@@ -1,13 +1,45 @@
+from abc import abstractclassmethod
 from nonebot import MessageSegment
 from hoshino.typing import MessageSegment
 
 from .autopcr.module.modulebase import ModuleManager
-from .util import draw
+from .util import draw, draw_line
 
 class Task():
     def __init__(self, alian, target, bot, ev, qid = None, gid = None):
         self.info = (alian, target, bot, ev, qid, gid)
 
+    @abstractclassmethod
+    async def do_task(self): ...
+
+class FindXinsui(Task):
+    async def do_task(self):
+        alian, target, bot, ev, qid, gid = self.info 
+        mgr = ModuleManager(target)
+        user_id = ev.user_id if ev else qid
+        try:
+            resp = await mgr.get_need_xinsui()
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + resp)
+        except Exception as e:
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+
+        return user_id, target
+
+class FindMemory(Task):
+    async def do_task(self):
+        alian, target, bot, ev, qid, gid = self.info 
+        mgr = ModuleManager(target)
+        user_id = ev.user_id if ev else qid
+        try:
+            resp = await mgr.get_need_memory()
+            img = await draw_line(resp, alian)
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
+        except Exception as e:
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+
+        return user_id, target
+
+class DailyClean(Task):
     async def do_task(self):
         alian, target, bot, ev, qid, gid = self.info 
         mgr = ModuleManager(target)

--- a/util.py
+++ b/util.py
@@ -38,6 +38,19 @@ def hightlight_rule(value):
         color = "#FFFFFF"
     return f"background-color: {color}"
 
+async def draw_line(data: list, alian: str):
+    tmp = {
+            "msg": [],
+            }
+    for value in data:
+        tmp["msg"].append(value)
+
+    df = pd.DataFrame(tmp)
+    df = df.style.set_table_styles([{'selector' : 'thead tr', 'props' : [('background-color', '#F5F5D5!important')]}, {'selector' : 'tr:nth-child(odd)', 'props' : [('background-color', '#E0E0FF')]}, {'selector' : 'tr:nth-child(even)', 'props' : [('background-color', '#F8F8F8')]}])
+    file = os.path.join(RESULT, f"{alian}_tmp.jpg")
+    imgkit.from_string(df.to_html(index=False, escape=False), file)
+    return file
+
 async def draw(data: dict, alian: str):
     tmp = {
             # "id": [],


### PR DESCRIPTION
mana的questid忘改了（

插件版新增新增【#查心碎】【#查记忆碎片】指令。
【#查心碎】会统计【已解锁角色】且【可解锁专武】的专武消耗，包括制作、升级至当前开放的最高级所需要的心碎数量（大心转换成10心碎），并减去仓库已有的心碎和大心（转换成10心碎），剩余还需刷取的数量。
【#查记忆碎片】会统计【已出角色】的从当前星级（未解锁则为0级）升至最高星（开六星就六星，否则五星）和专武制作升级至当前开放的最高级的记忆碎片消耗，并减去仓库已有记忆碎片数量，以升序给出

功能新增【智能刷hard图】，该功能将根据【#查记忆碎片】的结果，以缺少数量的升序顺序刷去对应的hard图，不支持从商店购买对应的角色碎片。等四周年体力减半掉率双倍后再加入外传刷取的支持（取消`sqlite3.py`里对应注释就可以了）
功能默认禁用。

然后把`do_task`的返回值都删掉了，统一用`_log`~~不再屎山了~~