### PR TITLE
Auto normal

### DIFF
--- a/_task.py
+++ b/_task.py
@@ -13,16 +13,33 @@ class Task():
     @abstractclassmethod
     async def do_task(self): ...
 
-class FindEquip(Task):
-    def __init__(self, start_rank = None, *args, **kwargs):
+class QuestRecommand(Task):
+    def __init__(self, start_rank = None, like_unit_only = None, *args, **kwargs):
         self.start_rank = start_rank
+        self.like_unit_only = like_unit_only
         super().__init__(*args, **kwargs)
 
     async def do_task(self):
         alian, target, bot, ev, qid, gid = self.info 
         mgr = ModuleManager(target)
         try:
-            resp = await mgr.get_need_equip(self.start_rank)
+            resp = await mgr.get_normal_quest_recommand(self.start_rank, self.like_unit_only)
+            img = await draw_line(resp, alian)
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
+        except Exception as e:
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+
+class FindEquip(Task):
+    def __init__(self, start_rank = None, like_unit_only = None, *args, **kwargs):
+        self.start_rank = start_rank
+        self.like_unit_only = like_unit_only
+        super().__init__(*args, **kwargs)
+
+    async def do_task(self):
+        alian, target, bot, ev, qid, gid = self.info 
+        mgr = ModuleManager(target)
+        try:
+            resp = await mgr.get_need_equip(self.start_rank, self.like_unit_only)
             img = await draw_line(resp, alian)
             await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
         except Exception as e:

--- a/_util.py
+++ b/_util.py
@@ -44,7 +44,7 @@ async def draw_line(data: list, alian: str):
             "msg": [],
             }
     for value in data:
-        tmp["msg"].append(value)
+        tmp["msg"].append(value.replace("\n", "<br />"))
 
     df = pd.DataFrame(tmp)
     df = df.style.set_table_styles([{'selector' : 'thead tr', 'props' : [('background-color', '#F5F5D5!important')]}, {'selector' : 'tr:nth-child(odd)', 'props' : [('background-color', '#E0E0FF')]}, {'selector' : 'tr:nth-child(even)', 'props' : [('background-color', '#F8F8F8')]}])

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -392,7 +392,7 @@ class pcrclient(apiclient):
         info = db.quest_info[quest]
         result: List[InventoryInfo] = []
         async def skip(times):
-            while self.data.stamina < info[1] * times:
+            while self.data.stamina < info.stamina * times:
                 if self.keys.get('buy_stamina_passive', 0) > self.data.recover_stamina_exec_count:
                     await self.recover_stamina()
                 else:
@@ -405,18 +405,18 @@ class pcrclient(apiclient):
                 return await self.hatsune_quest_skip(event, quest, times)
             else:
                 return await self.quest_skip(quest, times)
-        if info[0]:
+        if info.daily_limit:
             if is_total:
                 times -= qinfo.daily_clear_count
-            max_times = ((self.data.recover_max_time(quest) if recover else 0) + 1) * info[0] - qinfo.daily_clear_count
+            max_times = ((self.data.recover_max_time(quest) if recover else 0) + 1) * info.daily_limit - qinfo.daily_clear_count
             times = min(times, max_times)
             if times <= 0:
                 raise SkipError(f"任务{name}已达最大次数")
-            remain = info[0] * (qinfo.daily_recovery_count + 1) - qinfo.daily_clear_count
+            remain = info.daily_limit * (qinfo.daily_recovery_count + 1) - qinfo.daily_clear_count
             while times > 0:
                 if remain == 0:
                     await self.recover_challenge(quest)
-                    remain = info[0]
+                    remain = info.daily_limit
                 t = min(times, remain)
                 resp = await skip(t)
                 if resp.quest_result_list:

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -35,6 +35,13 @@ class database():
     def update(self, dbmgr: dbmgr):
         
         with dbmgr.session() as db:
+
+            self.normal_quest_data: Dict[int, QuestDatum] = (
+                QuestDatum.query(db)
+                .where(lambda x: self.is_normal_quest(x.quest_id)) 
+                .to_dict(lambda x: x.quest_id, lambda x: x)
+            )
+
             self.unique_equip_rank: Dict[int, UniqueEquipmentEnhanceDatum] = ( # 第二维是int？
                 UniqueEquipmentEnhanceDatum.query(db)
                 .group_by(lambda x: x.rank)
@@ -82,7 +89,7 @@ class database():
 
             self.memory_quest: Dict[int, List[QuestDatum]] = (
                 QuestDatum.query(db)
-                .where(lambda x: x.quest_id >= 12000000 and x.quest_id < 13000000)
+                .where(lambda x: self.is_hard_quest(x.quest_id))
                 .group_by(lambda x: x.reward_image_1)
                 .to_dict(lambda x: x.key, lambda x:
                     x.to_list()
@@ -194,11 +201,11 @@ class database():
                 .to_dict(lambda x: x.clan_battle_id, lambda x: x)
             )
 
-            self.quest_info: Dict[int, Tuple[int, int]] = (
+            self.quest_info: Dict[int, Tuple[int, QuestDatum]] = (
                 QuestDatum.query(db)
                 .concat(HatsuneQuest.query(db))
                 .concat(ShioriQuest.query(db))
-                .to_dict(lambda x: x.quest_id, lambda x: (x.daily_limit, x.stamina))
+                .to_dict(lambda x: x.quest_id, lambda x: x)
             )
 
             self.quest_name: Dict[int, str] = (
@@ -304,7 +311,7 @@ class database():
             
             self.six_area: Dict[int, QuestDatum] = (
                 QuestDatum.query(db)
-                .where(lambda x: x.quest_id >= 13000000 and x.quest_id < 14000000)
+                .where(lambda x: self.is_very_hard_quest(x.quest_id))
                 .to_dict(lambda x: x.quest_id, lambda x: x)
             )
 

--- a/autopcr/module/modules.py
+++ b/autopcr/module/modules.py
@@ -5,9 +5,11 @@ from .modulebase import *
 import datetime
 from ..model.error import *
 from ..db.database import db
+from ..db.models import *
 from ..model.models import *
 import random
 from abc import abstractmethod
+from collections import Counter
 
 @enumtype([x for x in range(-1, 24)])
 @default(-1)
@@ -26,6 +28,73 @@ class cron3(cron): ...
 
 @description('定时清日常4')
 class cron4(cron): ...
+
+
+@description('智能刷n图考虑的角色')
+@enumtype([1, 'max_rank', 'max_rank-1', 'max_rank-2', 'favorite'])
+@default(1)
+class smart_normal_sweep_unit(Module):
+    async def do_task(self, client: pcrclient):
+        client.keys['smart_normal_sweep_unit'] = self.value
+
+@description('智能刷n图')
+@enumtype(["none", "n庆典", "always"])
+@default("none")
+class smart_normal_sweep(Module):
+
+    async def do_task(self, client: pcrclient):
+        if self.value == "n庆典" and not client.data.is_normal_quest_double():
+            raise SkipError("今日非normal庆典，不刷取")
+
+        if client.keys['smart_normal_sweep_unit'] == 'favorite':
+            _, require_equip = client.data.get_need_equip(like_unit_only = True)
+        else:
+            opt = {
+                1: 1,
+                'max_rank': db.equip_max_rank,
+                'max_rank-1': db.equip_max_rank - 1,
+                'max_rank-2': db.equip_max_rank - 2,
+            }
+            _, require_equip = client.data.get_need_equip(start_rank = opt[client.keys['smart_normal_sweep_unit']])
+
+        clean_cnt = Counter()
+        quest_id = []
+        tmp = []
+        quest_list: List[int] = [id for id, quest in db.normal_quest_data.items() if db.parse_time(quest.start_time) <= datetime.datetime.now()]
+        stop: bool = False
+
+        try:
+            for i in range(10000):
+
+                if i % 3 == 0:
+                    quest_weight = client.data.get_quest_weght(require_equip)
+                    quest_id = sorted(quest_list, key = lambda x: quest_weight[x][0], reverse = True)
+
+                target_id = quest_id[0]
+                try:
+                    tmp.extend(await client.quest_skip_aware(target_id, 3))
+                    clean_cnt[target_id] += 3
+                except SkipError:
+                    pass
+                except AbortError as e:
+                    stop = True
+                    if str(e).endswith("体力不足"):
+                        if not tmp and not self.log: self._log(str(e))
+                    else:
+                        raise e
+                    break
+                if stop:
+                    break
+        except:
+            raise 
+        finally:
+            if tmp:
+                self._log(await client.serlize_reward(tmp))
+            if clean_cnt:
+                msg = '\n'.join((db.quest_name[quest] if quest in db.quest_name else f"未知关卡{quest}") +
+                f": 刷取{cnt}次" for quest, cnt in clean_cnt.items())
+                self._log(msg)
+
 
 @description('智能刷hard图')
 @enumtype(["none", "h庆典", "非n庆典", "always"])
@@ -1224,7 +1293,7 @@ class all_in_hatsune(Module):
         if not quest: raise SkipError("当前无进行中的活动")
         
 
-        count = client.data.stamina // db.quest_info[quest][1]
+        count = client.data.stamina // db.quest_info[quest].stamina
 
         if count == 0: raise AbortError("体力不足")
         await client.quest_skip_aware(quest, count)
@@ -1260,15 +1329,17 @@ def register_all():
         hatsune_h_sweep,
         hatsune_dear_reading,
         present_receive,
+        smart_sweep,
+        smart_hard_sweep,
+        smart_normal_sweep,
+
+        buy_stamina_active,
+        all_in_hatsune,
+
         hatsune_hboss_sweep,
         hatsune_mission_accept,
         hatsune_gacha_exchange,
         hatsune_mission_accept,
-        smart_sweep,
-        smart_hard_sweep,
-
-        buy_stamina_active,
-        all_in_hatsune,
 
         mission_receive_last,
 

--- a/autopcr/module/modules.py
+++ b/autopcr/module/modules.py
@@ -31,8 +31,8 @@ class cron4(cron): ...
 
 
 @description('智能刷n图考虑的角色')
-@enumtype([1, 'max_rank', 'max_rank-1', 'max_rank-2', 'favorite'])
-@default(1)
+@enumtype(['all', 'max_rank', 'max_rank-1', 'max_rank-2', 'favorite'])
+@default('all')
 class smart_normal_sweep_unit(Module):
     async def do_task(self, client: pcrclient):
         client.keys['smart_normal_sweep_unit'] = self.value
@@ -50,7 +50,7 @@ class smart_normal_sweep(Module):
             _, require_equip = client.data.get_need_equip(like_unit_only = True)
         else:
             opt = {
-                1: 1,
+                'all': 1,
                 'max_rank': db.equip_max_rank,
                 'max_rank-1': db.equip_max_rank - 1,
                 'max_rank-2': db.equip_max_rank - 2,
@@ -1331,6 +1331,7 @@ def register_all():
         present_receive,
         smart_sweep,
         smart_hard_sweep,
+        smart_normal_sweep_unit,
         smart_normal_sweep,
 
         buy_stamina_active,


### PR DESCRIPTION
- 新增【#刷图推荐】指令，根据装备缺口数量智能推荐刷取地图，按优先级高到底给出前10张推荐刷取地图，并给出该图掉落率最高的三个装备的缺口数量。
【#查装备】新增【fav】参数，加在指令最后，用于统计【Favorite角色】（角色列表里每个角色右上角的星星）。
【#刷图推荐】指令参数同上

- 新增【smart_normal_sweep】和【smart_normal_sweep_unit】功能，将根据上述指令结果刷取优先度最高的图。后者选项统计【所有角色】、【最高rank角色】、【次高rank角色】、【次次高rank角色】、【Favorite角色】。

- 【活动boss扫荡】和【讨伐证兑换】移至【all_in_hatsune】之后。