### PR TITLE
Fix explorer

### DIFF
--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -242,22 +242,19 @@ class datamgr(Component[apiclient]):
     def get_unique_equip_memory_demand(self, unit_id: int, token: ItemType) -> int:
         return self.get_unique_equip_material_demand(unit_id, token)
 
-    def get_max_avaliable_quest(self, quests: Dict[int, TrainingQuestDatum]) -> int:
+    def get_max_quest(self, quests: Dict[int, TrainingQuestDatum], available = False) -> int:
         now = datetime.datetime.now()
-        result = 0
-        for quest_id, quest in quests.items():
-            start_time = db.parse_time(quest.start_time)
-            if now < start_time:
-                continue
-            if quest_id in self.quest_dict and self.quest_dict[quest_id].clear_flg == 3:
-                result = max(result, quest_id)
-        return result
+        return (
+            flow(quests.keys())
+            .where(lambda x: now >= db.parse_time(quests[x].start_time) and quests[x].quest_id in self.quest_dict and (not available or self.quest_dict[x].clear_flg == 3))
+            .max()
+        )
 
-    def get_max_avaliable_quest_exp(self) -> int:
-        return self.get_max_avaliable_quest(db.training_quest_exp)
+    def get_max_quest_exp(self, sweep_available = False) -> int:
+        return self.get_max_quest(db.training_quest_exp, sweep_available)
 
-    def get_max_avaliable_quest_mana(self) -> int:
-        return self.get_max_avaliable_quest(db.training_quest_mana)
+    def get_max_quest_mana(self, sweep_available = False) -> int:
+        return self.get_max_quest(db.training_quest_mana, sweep_available)
 
     def update_inventory(self, item: InventoryInfo):
         token = (item.type, item.id)

--- a/autopcr/module/modulebase.py
+++ b/autopcr/module/modulebase.py
@@ -81,7 +81,10 @@ class Module:
         else:
             default = self.config[key].default
         value = self._parent.get_config(key, default)
-        if key != self.key and self.config[key].candidates and value not in self.config[key].candidates:
+        if key != self.key and self.config[key].candidates and (
+            value not in self.config[key].candidates and
+            any(item not in self.config[key].candidates for item in value)
+            ):
             value = default
         return value
 

--- a/autopcr/module/modules/autosweep.py
+++ b/autopcr/module/modules/autosweep.py
@@ -181,6 +181,7 @@ class smart_very_hard_sweep(Module):
 当被动体力回复完全消耗后，刷图结束
 '''.strip())
 @name("自定义刷图")
+@inttype('sweep_recover_stamina_times', "被动恢复体力数", 0, [i for i in range(41)])
 @default(False)
 class smart_sweep(Module):
     async def do_task(self, client: pcrclient):

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -46,38 +46,6 @@ class mission_receive_last(Module):
                 return
         raise SkipError("没有可领取的任务奖励")
 
-@description('自动扫荡最高等级的EXP探索')
-@name('EXP探索')
-@default(True)
-class explore_exp(Module):
-    async def do_task(self, client: pcrclient):
-        exp_quest_remain = client.data.training_quest_max_count.exp_quest - client.data.training_quest_count.exp_quest
-        if exp_quest_remain:
-            quest_id = client.data.get_max_avaliable_quest_exp()
-            if not quest_id:
-                raise AbortError("不存在可扫荡的exp探索")
-            name = db.quest_name[quest_id]
-            await client.training_quest_skip(quest_id, exp_quest_remain)
-            self._log(f"{name}扫荡{exp_quest_remain}次")
-        else:
-            raise SkipError("exp已扫荡")
-
-@description('自动扫荡最高等级的Mana探索')
-@name('Mana探索')
-@default(True)
-class explore_mana(Module):
-    async def do_task(self, client: pcrclient):
-        gold_quest_remain = client.data.training_quest_max_count.gold_quest - client.data.training_quest_count.gold_quest
-        if gold_quest_remain:
-            quest_id = client.data.get_max_avaliable_quest_mana()
-            if not quest_id:
-                raise AbortError("不存在可扫荡的mana探索")
-            name = db.quest_name[quest_id]
-            await client.training_quest_skip(quest_id, gold_quest_remain)
-            self._log(f"{name}扫荡{gold_quest_remain}次")
-        else:
-            raise SkipError("mana已扫荡")
-
 @singlechoice("present_receive_strategy", "领取策略", "非体力", ["非体力", "全部"])
 @description('领取符合条件的所有礼物箱奖励')
 @name('领取礼物箱')


### PR DESCRIPTION
探索新增非最高级别停止扫荡情况，以防增加12级扫荡时因未三星通关而扫荡11级。
`smart sweep`新增被动恢复体力选项。
修复了配置是列表类型时错误判断合法性的问题。