### PR TITLE
fix filename with multi periods

### DIFF
--- a/_util.py
+++ b/_util.py
@@ -16,7 +16,7 @@ async def get_info():
         with open(file, "r") as f:
             data = json.load(f)
             if 'qq' in data:
-                account = os.path.basename(file).split('.')[0]
+                account = '.'.join(os.path.basename(file).split('.')[:-1])
                 tmp[data['qq']].append((data, account))
     return tmp
 


### PR DESCRIPTION
修复了用户名包括若干个`.`的情况下会把所有的.后缀删除的问题