### PR TITLE
fix free gacha & optimize result

### DIFF
--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -112,7 +112,7 @@ class datamgr(Component[apiclient]):
             Counter((eInventoryType.Equip, equip.id) for equip in unit.equip_slot if equip.is_slot)
         )
 
-    def get_need_rarity_memory(self, unit_id: int, token: ItemType) -> int:
+    def get_rarity_memory_demand(self, unit_id: int, token: ItemType) -> int:
         rarity = -1
         if unit_id in self.unit:
             unit_data = self.unit[unit_id]
@@ -219,7 +219,7 @@ class datamgr(Component[apiclient]):
             if token not in db.inventory_name: # 未来角色
                 continue
 
-            need = self.get_need_rarity_memory(unit_id, token) + self.get_unique_equip_memory_demand(unit_id, token)
+            need = self.get_rarity_memory_demand(unit_id, token) + self.get_unique_equip_memory_demand(unit_id, token)
             result[token] += need
 
         return result

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -33,6 +33,12 @@ class pcrclient(apiclient):
         req = GachaIndexRequest()
         return await self.request(req)
 
+    async def gacha_select_prize(self, prizegacha_id: int, item_id: int):
+        req = GachaSelectPrizeRequest()
+        req.prizegacha_id = prizegacha_id
+        req.item_id = item_id
+        return await self.request(req)
+
     async def exec_gacha(self, gacha_id: int, gacha_times: int, exchange_id: int, draw_type: int, current_cost_num: int, campaign_id: int):
         req = GachaExecRequest()
         req.gacha_id = gacha_id

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -345,17 +345,27 @@ class database():
                 .to_dict(lambda x: x.dungeon_area_id, lambda x: x.dungeon_name)
             )
             
-            self.gacha_list: Dict[int, List[CampaignFreegachaDatum]] = (
+            self.free_gacha_list: Dict[int, List[CampaignFreegachaDatum]] = (
                 CampaignFreegachaDatum.query(db)
                 .group_by(lambda x: x.campaign_id)
                 .to_dict(lambda x: x.key, lambda x: x.to_list())
+            )
+
+            self.gacha_data: Dict[int, GachaDatum] = (
+                GachaDatum.query(db)
+                .to_dict(lambda x: x.gacha_id, lambda x: x)
+            )
+
+            self.prizegacha_data: Dict[int, PrizegachaDatum] = (
+                PrizegachaDatum.query(db)
+                .to_dict(lambda x: x.prizegacha_id, lambda x: x)
             )
             
             self.campaign_gacha: Dict[int, CampaignFreegacha] = (
                 CampaignFreegacha.query(db)
                 .to_dict(lambda x: x.campaign_id, lambda x: x)
             )
-            
+
             self.love_char: Dict[int, Tuple[int, int]] = (
                 LoveChara.query(db)
                 .group_by(lambda x: x.rarity)

--- a/autopcr/model/common.py
+++ b/autopcr/model/common.py
@@ -2004,16 +2004,16 @@ class Notification(BaseModel):
 	equip_donation: EquipDonateNotification = None
 	mission: List[MissionNotice] = None
 class PrizeRewardInfo(BaseModel):
-	prize1: PrizeRewardInfoDetail = None
-	prize2: PrizeRewardInfoDetail = None
-	prize3: PrizeRewardInfoDetail = None
-	prize4: PrizeRewardInfoDetail = None
-	prize5: PrizeRewardInfoDetail = None
-	prize6: PrizeRewardInfoDetail = None
-	prize7: PrizeRewardInfoDetail = None
-	prize8: PrizeRewardInfoDetail = None
-	prize9: PrizeRewardInfoDetail = None
-	prize10: PrizeRewardInfoDetail = None
+	prize_1: PrizeRewardInfoDetail = None
+	prize_2: PrizeRewardInfoDetail = None
+	prize_3: PrizeRewardInfoDetail = None
+	prize_4: PrizeRewardInfoDetail = None
+	prize_5: PrizeRewardInfoDetail = None
+	prize_6: PrizeRewardInfoDetail = None
+	prize_7: PrizeRewardInfoDetail = None
+	prize_8: PrizeRewardInfoDetail = None
+	prize_9: PrizeRewardInfoDetail = None
+	prize_10: PrizeRewardInfoDetail = None
 class TutorialQuestStart(BaseModel):
 	quest_wave_info: List[WaveEnemyInfoList] = None
 	limit_time: int = None

--- a/autopcr/module/modules/gacha.py
+++ b/autopcr/module/modules/gacha.py
@@ -5,6 +5,7 @@ from ...model.error import *
 from ...db.database import db
 from ...model.enums import *
 import datetime
+from collections import Counter
 
 @description('扭曲装备扭蛋')
 @name('普通扭蛋')
@@ -35,7 +36,7 @@ class free_gacha(Module):
         if res.campaign_info is None:
             raise SkipError("免费十连已结束")
         schedule = db.campaign_gacha[res.campaign_info.campaign_id]
-        gacha_list = db.gacha_list[schedule.campaign_id]
+        gacha_list = db.free_gacha_list[schedule.campaign_id]
         start_time = db.parse_time(schedule.start_time)
         end_time = db.parse_time(schedule.end_time)
         if datetime.datetime.now() >= end_time:
@@ -45,24 +46,46 @@ class free_gacha(Module):
         if res.campaign_info.fg10_exec_cnt == 0:
             raise SkipError("今日份免费十连已使用")
         cnt = res.campaign_info.fg10_exec_cnt
-        gacha_id = 0
-        exchange_id = 0
         gacha_list = set(gacha.gacha_id for gacha in gacha_list)
         for gacha_info in res.gacha_info:
             if gacha_info.id in gacha_list:
-                gacha_id = gacha_info.id
-                exchange_id = gacha_info.exchange_id
+                target_gacha = gacha_info
                 break
         else:
             raise ValueError("target gacha not found")
         reward_list = []
         new_unit = []
+        unit_rarity = Counter()
+        prize_rarity = Counter()
+        if target_gacha.selected_item_id == 0:
+            self._log("未选择奖励碎片")
+            prizegacha_id = db.gacha_data[target_gacha.id].prizegacha_id
+            if db.prizegacha_data[prizegacha_id].prize_memory_id_2 != 0:
+                raise AbortError("可选碎片大于一种，请自行手动选择")
+            item_id = db.prizegacha_data[prizegacha_id].prize_memory_id_1
+            await client.gacha_select_prize(prizegacha_id, item_id)
+            self._log(f"选择了{db.get_inventory_name_san((eInventoryType.Item, item_id))}")
+
         while cnt > 0:
-            resp = await client.exec_gacha(gacha_id, 10, exchange_id, 6, cnt, res.campaign_info.campaign_id)
+            resp = await client.exec_gacha(target_gacha.id, 10, target_gacha.exchange_id, 6, cnt, res.campaign_info.campaign_id)
             cnt -= 1
+
             new_unit += [item for item in resp.reward_info_list if item.type == eInventoryType.Unit]
             reward_list += [item for item in resp.reward_info_list if item.type != eInventoryType.Unit]
-            # bonues reward TODO
+
+            unit_rarity += Counter(item.unit_data.unit_rarity for item in resp.reward_info_list if item.type == eInventoryType.Unit)
+            unit_rarity += Counter(item.exchange_data.rarity for item in resp.reward_info_list if item.type != eInventoryType.Unit)
+
+            if resp.prize_reward_info:
+                prize_rarity += Counter(prize.rarity for prize in vars(resp.prize_reward_info).values() if prize is not None)
+                reward_list += [item for prize in vars(resp.prize_reward_info).values() if prize is not None for item in prize.rewards]
+            if resp.bonus_reward_info:
+                reward_list += [item for item in vars(resp.bonus_reward_info).values() if item is not None]
+
         if new_unit:
             self._log(f"NEW: \n" + '\n'.join([db.get_inventory_name(item) for item in new_unit]) + '\n')
+        if unit_rarity:
+            self._log(' '.join(["★"*i + f"x{cnt}" for i, cnt in unit_rarity.items()]))
+        if prize_rarity:
+            self._log(' '.join([f"{i}等" + f"x{cnt}" for i, cnt in prize_rarity.items()]))
         self._log(await client.serlize_reward(reward_list))


### PR DESCRIPTION
修复了免费十连不能抽取复刻池的问题，碎片选择只有一个则会自动选，否则会提醒用户自行选择一个
优化了抽取结果的展示，新增了角色星级和奖励等级的统计，获得物也包括奖励所得和up碎片