### PR TITLE
Jjc

### DIFF
--- a/_task.py
+++ b/_task.py
@@ -43,27 +43,27 @@ class JJCBack(TaskList):
     def do_module_list(self) -> list:
         return ["jjc_back"]
 
-class QuestRecommand(Task):
+class QuestRecommand(TaskList):
     def do_module_list(self) -> list:
         return ["get_normal_quest_recommand"]
 
-class FindEquip(Task):
+class FindEquip(TaskList):
     def do_module_list(self) -> list:
         return ["get_need_equip"]
 
-class GetLibraryImport(Task):
+class GetLibraryImport(TaskList):
     def do_module_list(self) -> list:
         return ["get_library_import_data"]
 
-class FindXinsui(Task):
+class FindXinsui(TaskList):
     def do_module_list(self) -> list:
         return ["get_need_xinsui"]
 
-class FindMemory(Task):
+class FindMemory(TaskList):
     def do_module_list(self) -> list:
         return ["get_need_memory"]
 
-class Gacha(Task):
+class Gacha(TaskList):
     def do_module_list(self) -> list:
         return ["gacha_start"]
 

--- a/_task.py
+++ b/_task.py
@@ -1,4 +1,4 @@
-from abc import abstractclassmethod
+from abc import abstractclassmethod, abstractproperty
 from nonebot import MessageSegment
 from hoshino.typing import MessageSegment
 
@@ -16,88 +16,50 @@ class Task():
     @abstractclassmethod
     async def do_task(self): ...
 
-class ClanBattleSupport(Task):
+class TaskList(Task):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @abstractproperty
+    def do_module_list(self) -> list: ...
+
     async def do_task(self):
         alian, target, bot, ev, qid, gid = self.info
         try:
             async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ["get_clan_support_unit"])
+                resp = await mgr.do_from_key(self.config, self.do_module_list)
             img = await draw(resp, alian)
             await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
         except Exception as e:
             await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+
+class ClanBattleSupport(TaskList):
+    def do_module_list(self) -> list:
+        return ["get_clan_support_unit"]
 
 class QuestRecommand(Task):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    async def do_task(self):
-        alian, target, bot, ev, qid, gid = self.info 
-        try:
-            async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ['get_normal_quest_recommand'])
-            img = await draw(resp, alian)
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
-        except Exception as e:
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+    def do_module_list(self) -> list:
+        return ["get_normal_quest_recommand"]
 
 class FindEquip(Task):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    async def do_task(self):
-        alian, target, bot, ev, qid, gid = self.info 
-        try:
-            async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ['get_need_equip'])
-            img = await draw(resp, alian)
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
-        except Exception as e:
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+    def do_module_list(self) -> list:
+        return ["get_need_equip"]
 
 class GetLibraryImport(Task):
-    async def do_task(self):
-        alian, target, bot, ev, qid, gid = self.info 
-        try:
-            async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ["get_library_import_data"])
-            msg = render_forward_msg([resp])
-            await bot.send_group_forward_msg(group_id=ev.group_id, messages=msg)
-        except Exception as e:
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+    def do_module_list(self) -> list:
+        return ["get_library_import_data"]
 
 class FindXinsui(Task):
-    async def do_task(self):
-        alian, target, bot, ev, qid, gid = self.info
-        try:
-            async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ["get_need_xinsui"])
-            img = await draw(resp, alian)
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
-        except Exception as e:
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+    def do_module_list(self) -> list:
+        return ["get_need_xinsui"]
 
 class FindMemory(Task):
-    async def do_task(self):
-        alian, target, bot, ev, qid, gid = self.info
-        try:
-            async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ["get_need_memory"])
-            img = await draw(resp, alian)
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
-        except Exception as e:
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+    def do_module_list(self) -> list:
+        return ["get_need_memory"]
 
 class Gacha(Task):
-    async def do_task(self):
-        alian, target, bot, ev, qid, gid = self.info
-        try:
-            async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, ["gacha_start"])
-            img = await draw(resp, alian)
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
-        except Exception as e:
-            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+    def do_module_list(self) -> list:
+        return ["gacha_start"]
 
 class DailyClean(Task):
     async def do_task(self):

--- a/_task.py
+++ b/_task.py
@@ -16,6 +16,17 @@ class Task():
     @abstractclassmethod
     async def do_task(self): ...
 
+class ClanBattleSupport(Task):
+    async def do_task(self):
+        alian, target, bot, ev, qid, gid = self.info
+        try:
+            async with accountmgr.load(target) as mgr:
+                resp = await mgr.do_from_key(self.config, ["get_clan_support_unit"])
+            img = await draw(resp, alian)
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
+        except Exception as e:
+            await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
+
 class QuestRecommand(Task):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/_task.py
+++ b/_task.py
@@ -1,6 +1,7 @@
 from abc import abstractclassmethod, abstractproperty
 from nonebot import MessageSegment
 from hoshino.typing import MessageSegment
+import traceback
 
 from .autopcr.module.accountmgr import instance as accountmgr
 from ._util import draw, render_forward_msg
@@ -20,22 +21,27 @@ class TaskList(Task):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @abstractproperty
+    @abstractclassmethod
     def do_module_list(self) -> list: ...
 
     async def do_task(self):
         alian, target, bot, ev, qid, gid = self.info
         try:
             async with accountmgr.load(target) as mgr:
-                resp = await mgr.do_from_key(self.config, self.do_module_list)
+                resp = await mgr.do_from_key(self.config, self.do_module_list())
             img = await draw(resp, alian)
             await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
         except Exception as e:
+            traceback.print_exc()
             await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + str(e))
 
 class ClanBattleSupport(TaskList):
     def do_module_list(self) -> list:
         return ["get_clan_support_unit"]
+
+class JJCBack(TaskList):
+    def do_module_list(self) -> list:
+        return ["jjc_back"]
 
 class QuestRecommand(Task):
     def do_module_list(self) -> list:

--- a/_task.py
+++ b/_task.py
@@ -29,7 +29,7 @@ class TaskList(Task):
         try:
             async with accountmgr.load(target) as mgr:
                 resp = await mgr.do_from_key(self.config, self.do_module_list())
-            img = await draw(resp, alian)
+            img = await draw(resp, alian + '_'.join(self.do_module_list()))
             await bot.send(ev, f"[CQ:reply,id={ev.message_id}]" + MessageSegment.image(f'file:///{img}'))
         except Exception as e:
             traceback.print_exc()

--- a/autopcr/bsdk/bsdkclient.py
+++ b/autopcr/bsdk/bsdkclient.py
@@ -16,7 +16,6 @@ class bsdkclient:
     '''
 
     def __init__(self, acccountinfo, captchaVerifier=autoValidator, errlogger=_defaultLogger):
-    # def __init__(self, acccountinfo, captchaVerifier=manualValidator, errlogger=_defaultLogger):
         self.account = acccountinfo['account']
         self.pwd = acccountinfo['password']
         self.platform = acccountinfo['platform']

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -136,12 +136,12 @@ class datamgr(Component[apiclient]):
         rank = self.unit[unit_id].unique_equip_slot[0].rank if unit_id in self.unit and self.unit[unit_id].unique_equip_slot else -1
         return (
             flow(db.unique_equip_required[equip_id].items())
-            .where(lambda x: x[0] > rank)
+            .where(lambda x: x[0] >= rank)
             .select(lambda x: x[1][token])
             .sum()
         )
 
-    def get_need_unit_need_eqiup(self, unit_id: int) -> typing.Counter[ItemType]:
+    def get_unit_eqiup_demand(self, unit_id: int) -> typing.Counter[ItemType]:
         unit = self.unit[unit_id]
         rank = unit.promotion_level
 
@@ -242,7 +242,7 @@ class datamgr(Component[apiclient]):
                 continue
             if like_unit_only and not self.unit[unit_id].favorite_flag:
                 continue
-            need = self.get_need_unit_need_eqiup(unit_id)
+            need = self.get_unit_eqiup_demand(unit_id)
             if need:
                 cnt += need
         return cnt 

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -28,6 +28,8 @@ class datamgr(Component[apiclient]):
     donation_num: int = 0
     team_level: int = 0
     stamina: int = 0
+    missions: List[UserMissionInfo] = None
+    growth_unit: Dict[int, GrowthInfo] = None
     unit: Dict[int, UnitData] = None
     unit_love_data: Dict[int, UserChara] = None
     recover_stamina_exec_count: int = 0
@@ -367,6 +369,15 @@ class datamgr(Component[apiclient]):
 
     def is_empty_deck(self, party_type: ePartyType):
         return all(value == 0 for key, value in vars(self.deck_list[party_type]).items() if key.startswith('unit_id'))
+
+    def is_mission_finished(self, system_id: int):
+        return len(list(
+            flow(self.missions)
+            .where(lambda x: 
+                   db.is_daily_mission(x.mission_id) and
+                   x.mission_status != eMissionStatusType.NoClear and 
+                   db.daily_mission_data[x.mission_id].system_id == system_id)
+        )) != 0
 
     async def request(self, request: Request[TResponse], next: RequestHandler) -> TResponse:
         resp = await next.request(request)

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -131,7 +131,7 @@ class datamgr(Component[apiclient]):
         self.hatsune_quest_dict.clear()
 
     def get_unique_equip_material_demand(self, equip_slot:int, unit_id: int, token: ItemType) -> int:
-        if unit_id not in db.unit_unique_equip:
+        if unit_id not in db.unit_unique_equip[equip_slot]:
             return 0
         equip_id = db.unit_unique_equip[equip_slot][unit_id].equip_id
         rank = self.unit[unit_id].unique_equip_slot[0].rank if unit_id in self.unit and self.unit[unit_id].unique_equip_slot else -1

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -267,7 +267,7 @@ class datamgr(Component[apiclient]):
             if token not in db.inventory_name: # 未来角色
                 continue
 
-            need = self.get_rarity_memory_demand(unit_id, token) + self.get_unique_equip_memory_demand(unit_id, token) + self.get_exceed_level_unit_demand(unit_id, token)
+            need = self.get_rarity_memory_demand(unit_id, token) + self.get_unique_equip_memory_demand(unit_id, token) + self.get_exceed_level_unit_demand(unit_id, token) * 0
             result[token] += need
 
         return result

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -357,7 +357,11 @@ class datamgr(Component[apiclient]):
         else:
             raise ValueError(f"未知的商店{shop_id}")
 
+    def is_empty_deck(self, party_type: ePartyType):
+        return all(value == 0 for key, value in vars(self.deck_list[party_type]).items() if key.startswith('unit_id'))
+
     async def request(self, request: Request[TResponse], next: RequestHandler) -> TResponse:
         resp = await next.request(request)
         if resp: await resp.update(self, request)
         return resp
+

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -153,6 +153,13 @@ class datamgr(Component[apiclient]):
             Counter((eInventoryType.Equip, equip.id) for equip in unit.equip_slot if equip.is_slot)
         )
 
+    def get_exceed_level_unit_demand(self, unit_id: int, token: ItemType) -> int:
+        if unit_id in self.unit and self.unit[unit_id].exceed_stage:
+            return 0
+        if unit_id not in db.exceed_level_unit_required: # 怎么还没有环奈
+            return 0
+        return db.exceed_level_unit_required[unit_id].consume_num_1 # 1 memory 2 ring
+
     def get_rarity_memory_demand(self, unit_id: int, token: ItemType) -> int:
         rarity = -1
         if unit_id in self.unit:
@@ -260,7 +267,7 @@ class datamgr(Component[apiclient]):
             if token not in db.inventory_name: # 未来角色
                 continue
 
-            need = self.get_rarity_memory_demand(unit_id, token) + self.get_unique_equip_memory_demand(unit_id, token)
+            need = self.get_rarity_memory_demand(unit_id, token) + self.get_unique_equip_memory_demand(unit_id, token) + self.get_exceed_level_unit_demand(unit_id, token)
             result[token] += need
 
         return result

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -26,6 +26,37 @@ class pcrclient(apiclient):
     async def logout(self):
         await self.session.clear_session()
 
+    async def skill_level_up(self, unit_id: int, skill_levelup_list: List[SkillLevelUpDetail]):
+        req = SkillLevelUpRequest()
+        req.unit_id = unit_id
+        req.skill_levelup_list = skill_levelup_list
+        return await self.request(req)
+
+    async def unit_free_level_up(self, unit_id: int, after_level: int):
+        req = UnitFreeLevelUpRequest()
+        req.unit_id = unit_id
+        req.after_level = after_level
+        return await self.request(req)
+
+    async def unit_free_promotion(self, unit_id: int, target_promotion_level: int):
+        req = UnitFreePromotionRequest()
+        req.unit_id = unit_id
+        req.target_promotion_level = target_promotion_level
+        return await self.request(req)
+
+    async def unit_free_equip(self, unit_id: int, equip_slot_num_list: List[int]):
+        req = UnitFreeEquipRequest()
+        req.unit_id = unit_id
+        req.equip_slot_num_list = equip_slot_num_list
+        return await self.request(req)
+
+    async def equipment_free_enhance(self, unit_id: int, equip_slot_num: int, after_equip_level: int):
+        req = EquipmentFreeEnhanceRequest()
+        req.unit_id = unit_id
+        req.equip_slot_num = equip_slot_num
+        req.after_equip_level = after_equip_level
+        return await self.request(req)
+
     async def get_clan_battle_top(self, clan_id: int, is_first: int, current_clan_battle_coin: int):
         req = ClanBattleTopRequest()
         req.clan_id = clan_id
@@ -36,6 +67,12 @@ class pcrclient(apiclient):
     async def get_clan_battle_support_unit_list(self, clan_id: int):
         req = ClanBattleSupportUnitList2Request()
         req.clan_id = clan_id
+        return await self.request(req)
+
+    async def arena_rank(self, limit: int, page: int):
+        req = ArenaRankingRequest()
+        req.limit = limit
+        req.page = page
         return await self.request(req)
 
     async def arena_apply(self, battle_viewer_id: int, opponent_rank: int):
@@ -384,6 +421,10 @@ class pcrclient(apiclient):
     async def recover_stamina(self):
         req = ShopRecoverStaminaRequest()
         req.current_currency_num = self.data.jewel.free_jewel + self.data.jewel.jewel
+        return await self.request(req)
+
+    async def get_arena_history(self):
+        req = ArenaHistoryRequest()
         return await self.request(req)
     
     async def get_arena_info(self):

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -26,6 +26,18 @@ class pcrclient(apiclient):
     async def logout(self):
         await self.session.clear_session()
 
+    async def get_clan_battle_top(self, clan_id: int, is_first: int, current_clan_battle_coin: int):
+        req = ClanBattleTopRequest()
+        req.clan_id = clan_id
+        req.is_first = is_first
+        req.current_clan_battle_coin = current_clan_battle_coin
+        return await self.request(req)
+
+    async def get_clan_battle_support_unit_list(self, clan_id: int):
+        req = ClanBattleSupportUnitList2Request()
+        req.clan_id = clan_id
+        return await self.request(req)
+
     async def arena_apply(self, battle_viewer_id: int, opponent_rank: int):
         req = ArenaApplyRequest()
         req.battle_viewer_id = battle_viewer_id
@@ -441,6 +453,60 @@ class pcrclient(apiclient):
         if target is not None and len(result) == 0:
             result.append(f"{db.get_inventory_name_san(target)}x0({self.data.get_inventory(target)})")
         return '\n'.join(result)
+
+    async def serialize_unit_info(self, unit_data: Union[UnitData, UnitDataLight]) -> Tuple[bool, str]:
+        info = []
+        ok = True
+        def add_info(prefix, cur, expect = None):
+            if expect:
+                nonlocal ok
+                info.append(f'{prefix}:{cur}/{expect}')
+                ok &= (cur == expect)
+            else:
+                info.append(f'{prefix}:{cur}')
+        unit_id = unit_data.id
+        add_info("等级", unit_data.unit_level, db.team_max_level)
+        if unit_data.battle_rarity:
+            add_info("星级", f"{unit_data.battle_rarity}-{unit_data.unit_rarity}")
+        else:
+            add_info("星级", f"{unit_data.unit_rarity}")
+        add_info("品级", unit_data.promotion_level, db.equip_max_rank)
+        for id, union_burst in enumerate(unit_data.union_burst):
+            if union_burst.skill_level:
+                add_info(f"ub{id}", union_burst.skill_level, unit_data.unit_level)
+        for id, skill in enumerate(unit_data.main_skill):
+            if skill.skill_level:
+                add_info(f"skill{id}", skill.skill_level, unit_data.unit_level)
+        for id, skill in enumerate(unit_data.ex_skill):
+            if skill.skill_level:
+                add_info(f"ex{id}", skill.skill_level, unit_data.unit_level)
+        equip_info = []
+        for id, equip in enumerate(unit_data.equip_slot):
+            equip_id = getattr(db.unit_promotion[unit_id][unit_data.promotion_level], f'equip_slot_{id + 1}')
+            if not equip.is_slot:
+                if equip_id != 999999:
+                    equip_info.append('-')
+                    ok = False
+                else:
+                    equip_info.append('*')
+            else:
+                star = db.get_equip_star_from_pt(equip_id, equip.enhancement_pt)
+                ok &= (star == 5)
+                equip_info.append(str(star))
+        equip_info = '/'.join(equip_info)
+        add_info("装备", equip_info)
+
+        for id, equip in enumerate(unit_data.unique_equip_slot):
+            equip_slot = id + 1
+            have_unique = (equip_slot in db.unit_unique_equip and unit_id in db.unit_unique_equip[equip_slot])
+            max_level = 0 if not have_unique else db.unique_equipment_max_level[equip_slot]
+            if have_unique:
+                if not equip.is_slot:
+                    add_info(f"专武{id}", '-', max_level)
+                else:
+                    add_info(f"专武{id}", db.get_unique_equip_level_from_pt(equip_slot, equip.enhancement_pt), max_level)
+        
+        return ok, ' '.join(info)
 
     async def recover_challenge(self, quest: int):
         req = QuestRecoverChallengeRequest()

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -23,6 +23,37 @@ class pcrclient(apiclient):
     async def login(self):
         await self.request(None)
 
+    async def logout(self):
+        await self.session.clear_session()
+
+    async def arena_apply(self, battle_viewer_id: int, opponent_rank: int):
+        req = ArenaApplyRequest()
+        req.battle_viewer_id = battle_viewer_id
+        req.opponent_rank = opponent_rank
+        return await self.request(req)
+
+    async def arena_start(self, token: str, battle_viewer_id: int, remain_battle_number: int, disable_skin: int):
+        req = ArenaStartRequest()
+        req.token = token
+        req.battle_viewer_id = battle_viewer_id
+        req.remain_battle_number = remain_battle_number
+        req.disable_skin = disable_skin
+        return await self.request(req)
+
+    async def grand_arena_apply(self, battle_viewer_id: int, opponent_rank: int):
+        req = GrandArenaApplyRequest()
+        req.battle_viewer_id = battle_viewer_id
+        req.opponent_rank = opponent_rank
+        return await self.request(req)
+
+    async def grand_arena_start(self, token: str, battle_viewer_id: int, remain_battle_number: int, disable_skin: int):
+        req = GrandArenaStartRequest()
+        req.token = token
+        req.battle_viewer_id = battle_viewer_id
+        req.remain_battle_number = remain_battle_number
+        req.disable_skin = disable_skin
+        return await self.request(req)
+
     async def multi_give_gift(self, unit_id: int, cakes: List[SendGiftData]):
         req = RoomMultiGiveGiftRequest()
         req.unit_id = unit_id
@@ -268,12 +299,18 @@ class pcrclient(apiclient):
         req.join_condition = cond
         await self.request(req)
 
-    async def get_clan_info(self) -> ClanData:
+    async def get_clan_info(self):
         if self.data.clan == 0: return None
         req = ClanInfoRequest()
         req.clan_id = self.data.clan
         req.get_user_equip = 0
-        return (await self.request(req)).clan
+        return (await self.request(req))
+
+    async def request_equip(self, equip_id: int, clan_id: int):
+        req = EquipRequestRequest()
+        req.equip_id = equip_id
+        req.clan_id = clan_id
+        return await self.request(req)
     
     async def donate_equip(self, request: EquipRequests, times: int):
         req = EquipDonateRequest()

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -349,6 +349,12 @@ class pcrclient(apiclient):
         req.quest_id = quest
         req.random_count = times
         return await self.request(req)
+
+    async def equip_get_request(self, clan_id: int, message_id: int):
+        req = EquipGetRequestRequest()
+        req.clan_id = clan_id
+        req.message_id = message_id
+        return await self.request(req)
     
     async def getrequests(self):
         req = ClanChatInfoListRequest()

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -26,6 +26,19 @@ class pcrclient(apiclient):
     async def logout(self):
         await self.session.clear_session()
 
+    async def deck_update(self, deck_number: int, units: List[int]):
+        req = DeckUpdateRequest()
+        req.deck_number = deck_number
+        cnt = len(units)
+        for i in range(1, 6):
+            setattr(req, f"unit_id_{i}",units[i - 1] if i <= cnt else 0) 
+        return await self.request(req)
+
+    async def unit_change_rarity(self, change_rarity_unit_list: List[ChangeRarityUnit]):
+        req = ChangeRarityRequest()
+        req.change_rarity_unit_list = change_rarity_unit_list
+        return await self.request(req)
+
     async def skill_level_up(self, unit_id: int, skill_levelup_list: List[SkillLevelUpDetail]):
         req = SkillLevelUpRequest()
         req.unit_id = unit_id

--- a/autopcr/core/sessionmgr.py
+++ b/autopcr/core/sessionmgr.py
@@ -1,7 +1,7 @@
 from .base import Component, RequestHandler
 from .apiclient import apiclient, ApiException
 from ..bsdk.bsdkclient import bsdkclient
-import asyncio, json, re, os, random
+import json, os, random
 from ..model.models import *
 from ..constants import CACHE_DIR
 import hashlib
@@ -48,6 +48,27 @@ class sessionmgr(Component[apiclient]):
                     )
                     if not (await next.request(req)).is_risk:
                         break
+                    else:
+                        for _ in range(5):
+                            from ..bsdk.bsgamesdk import captch
+                            cap=await captch()
+                            captch_done=await self.bsdk.captchaVerifier(self.bsdk.account, cap['gt'], cap['challenge'], cap['gt_user_id'])
+                            req = ToolSdkLoginRequest(
+                                uid=self._sdkaccount['uid'],
+                                access_key=self._sdkaccount['access_key'],
+                                platform=str(self._platform),
+                                channel_id=str(self._channel),
+                                challenge=captch_done['challenge'],
+                                validate_=captch_done['validate'],
+                                seccode=capch_done['validate']+"|jordan",
+                                captcha_type='1',
+                                image_token='',
+                                captcha_code='',
+                            )
+                            if not (await next.request(req)).is_risk:
+                                break
+                        else:
+                            raise ValueError("登录失败，帐号存在风险")
                 except ApiException:
                     pass
             

--- a/autopcr/core/sessionmgr.py
+++ b/autopcr/core/sessionmgr.py
@@ -106,3 +106,6 @@ class sessionmgr(Component[apiclient]):
             if ex.status == 3 and self.auto_relogin:
                 self._logged = False
             raise
+
+    async def clear_session(self):
+        self._logged = False

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -117,6 +117,11 @@ class database():
                 UnitUniqueEquip.query(db)
                 .to_dict(lambda x: x.unit_id, lambda x: x)
             )
+
+            self.exceed_level_unit_required: Dict[int, ExceedLevelUnit] = (
+                ExceedLevelUnit.query(db)
+                .to_dict(lambda x: x.unit_id, lambda x: x)
+            )
             
             self.rarity_up_required: Dict[int, Dict[int, typing.Counter[ItemType]]] = (
                 UnitRarity.query(db)

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -73,7 +73,16 @@ class database():
                 )
             )
 
-            self.unit_promotion: Dict[int, Dict[int, typing.Counter[ItemType]]] = (
+            self.unit_promotion: Dict[int, Dict[int, UnitPromotion]] = (
+                UnitPromotion.query(db)
+                .group_by(lambda x: x.unit_id)
+                .to_dict(lambda x: x.key, lambda x:
+                    x.to_dict(lambda y: y.promotion_level, lambda y: y
+                    )
+                )
+            )
+
+            self.unit_promotion_equip_count: Dict[int, Dict[int, typing.Counter[ItemType]]] = (
                 UnitPromotion.query(db)
                 .group_by(lambda x: x.unit_id)
                 .to_dict(lambda x: x.key, lambda x:
@@ -91,7 +100,7 @@ class database():
             )
 
             self.equip_max_rank_equip_num: int = max(
-                len(x.get(self.equip_max_rank, {})) for x in self.unit_promotion.values()
+                len(x.get(self.equip_max_rank, {})) for x in self.unit_promotion_equip_count.values()
             )
 
             self.hatsune_schedule: Dict[int, HatsuneSchedule] = (
@@ -113,10 +122,23 @@ class database():
                 )
             )
 
-            self.unit_unique_equip: Dict[int, UnitUniqueEquip] = (
+            self.unit_unique_equip: Dict[int, Dict[int, UnitUniqueEquip]] = (
                 UnitUniqueEquip.query(db)
-                .to_dict(lambda x: x.unit_id, lambda x: x)
+                .group_by(lambda x: x.equip_slot)
+                .to_dict(lambda x: x.key, lambda x: 
+                    x.to_dict(lambda x: x.unit_id, lambda x: x))
             )
+
+            self.unique_equipment_enhance_data: Dict[int, Dict[int, UniqueEquipmentEnhanceDatum]] = (
+                UniqueEquipmentEnhanceDatum.query(db)
+                .group_by(lambda x: x.equip_slot)
+                .to_dict(lambda x: x.key, lambda x: 
+                     x.to_dict(lambda x: x.enhance_level, lambda x: x))
+            )
+
+            self.unique_equipment_max_level: Dict[int, int] = {
+                equip_slot: max(self.unique_equipment_enhance_data[equip_slot].keys()) for equip_slot in self.unique_equipment_enhance_data
+            }
 
             self.exceed_level_unit_required: Dict[int, ExceedLevelUnit] = (
                 ExceedLevelUnit.query(db)
@@ -265,10 +287,12 @@ class database():
                 .to_dict(lambda x: x.tower_quest_id, lambda x: x)
             )
 
-            self.team_max_stamina: Dict[int, ExperienceTeam] = (
+            self.team_info: Dict[int, ExperienceTeam] = (
                 ExperienceTeam.query(db)
                 .to_dict(lambda x: x.team_level, lambda x: x)
             )
+
+            self.team_max_level: int = max(self.team_info.keys()) - 1
 
             self.event_story: List[EventStoryDetail] = (
                 EventStoryDetail.query(db)
@@ -287,6 +311,13 @@ class database():
             self.equip_data: Dict[int, EquipmentDatum] = (
                 EquipmentDatum.query(db)
                 .to_dict(lambda x: x.equipment_id, lambda x: x)
+            )
+
+            self.equipment_enhance_data: Dict[int, Dict[int, EquipmentEnhanceDatum]] = (
+                EquipmentEnhanceDatum.query(db)
+                .group_by(lambda x: x.promotion_level)
+                .to_dict(lambda x: x.key, lambda x: 
+                     x.to_dict(lambda x: x.equipment_enhance_level, lambda x: x))
             )
 
             self.inventory_name: Dict[ItemType, str] = (
@@ -592,5 +623,16 @@ class database():
         .where(lambda x: self.parse_time(x.start_time) <= now and now <= self.parse_time(x.end_time)) \
         .select(lambda x: f"{x.gacha_id}: {x.gacha_name}-{x.pick_up_chara_text}") \
         .to_list()
+
+    def get_equip_star_from_pt(self, equip_id: int, enhancement_pt: int):
+        equip = self.equip_data[equip_id]
+        history_star = [star for star, enhancement_data in self.equipment_enhance_data[equip.promotion_level].items() if enhancement_data.total_point <= enhancement_pt]
+        star = max([0] + history_star)
+        return star
+
+    def get_unique_equip_level_from_pt(self, equip_slot: int, enhancement_pt: int):
+        histort_level = [star for star, enhancement_data in self.unique_equipment_enhance_data[equip_slot].items() if enhancement_data.total_point <= enhancement_pt]
+        level = max([1] + histort_level)
+        return level
 
 db = database()

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -284,6 +284,11 @@ class database():
                 .to_list()
             )
 
+            self.equip_data: Dict[int, EquipmentDatum] = (
+                EquipmentDatum.query(db)
+                .to_dict(lambda x: x.equipment_id, lambda x: x)
+            )
+
             self.inventory_name: Dict[ItemType, str] = (
                 EquipmentDatum.query(db)
                 .select(lambda x: (eInventoryType(eInventoryType.Equip), x.equipment_id, x.equipment_name))

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -479,13 +479,13 @@ class database():
         try:
             return self.inventory_name[(eInventoryType.Item, item_id)]
         except:
-            return f"未知装备({item_id})"
+            return f"未知物品({item_id})"
 
     def get_room_item_name(self, item_id: int) -> str:
         try:
             return self.inventory_name[(eInventoryType.RoomItem, item_id)]
         except:
-            return f"未知装备({item_id})"
+            return f"未知房间物品({item_id})"
 
     def is_daily_mission(self, mission_id: int) -> bool:
         return mission_id in self.daily_mission_data

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -352,16 +352,20 @@ class database():
                 .to_dict(lambda x: x.id, lambda x: x)
             )
             
-            self.daily_mission: Set[int] = (
+            self.daily_mission_data: Dict[int, DailyMissionDatum] = (
                 DailyMissionDatum.query(db)
-                .select(lambda x: x.daily_mission_id)
-                .to_set()
+                .to_dict(lambda x: x.daily_mission_id, lambda x: x)
             )
             
             self.memory_to_unit: Dict[int, int] = (
                 UnitRarity.query(db)
                 .group_by(lambda x: x.unit_material_id)
                 .to_dict(lambda x: x.key, lambda x: x.first().unit_id)
+            )
+
+            self.growth_parameter: Dict[int, GrowthParameter] = (
+                GrowthParameter.query(db)
+                .to_dict(lambda x: x.growth_id, lambda x: x)
             )
 
             self.unit_data: Dict[int, UnitDatum] = (
@@ -459,8 +463,32 @@ class database():
         except:
             return f"未知物品({item[1]})"
 
+    def get_unit_name(self, unit_id: int) -> str:
+        try:
+            return self.inventory_name[(eInventoryType.Unit, unit_id)]
+        except:
+            return f"未知角色({unit_id})"
+
+    def get_equip_name(self, equip_id: int) -> str:
+        try:
+            return self.inventory_name[(eInventoryType.Equip, equip_id)]
+        except:
+            return f"未知装备({equip_id})"
+
+    def get_item_name(self, item_id: int) -> str:
+        try:
+            return self.inventory_name[(eInventoryType.Item, item_id)]
+        except:
+            return f"未知装备({item_id})"
+
+    def get_room_item_name(self, item_id: int) -> str:
+        try:
+            return self.inventory_name[(eInventoryType.RoomItem, item_id)]
+        except:
+            return f"未知装备({item_id})"
+
     def is_daily_mission(self, mission_id: int) -> bool:
-        return mission_id in self.daily_mission
+        return mission_id in self.daily_mission_data
 
     def is_exp_upper(self, item: ItemType) -> bool:
         return item[0] == eInventoryType.Item and item[1] >= 20000 and item[1] < 21000

--- a/autopcr/model/custom.py
+++ b/autopcr/model/custom.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from .enums import eInventoryType
 from typing import List, Tuple, Counter as CounterType
 from collections import Counter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 ItemType = Tuple[eInventoryType, int]
 
@@ -40,3 +40,15 @@ class GachaReward():
         self.prize_rarity += oth.prize_rarity
 
         return self
+
+
+class ArenaQueryUnit(BaseModel):
+    equip: bool = None
+    id: int = None
+    star: int = None
+
+class ArenaQueryResponse(BaseModel):
+    id: int = None
+    atk: List[ArenaQueryUnit] = None
+    up: int = None
+    down: int = None

--- a/autopcr/model/enums.py
+++ b/autopcr/model/enums.py
@@ -446,3 +446,11 @@ class eBattleLogType(Enum):
 	WAVE_END_DAMAGE_AMOUNT = 13
 	BREAK = 14
 	INVALID_VALUE = -1
+
+class eClanSupportMemberType(Enum):
+    NONE = 0
+    DUNGEON_SUPPORT_UNIT_1 = 1
+    DUNGEON_SUPPORT_UNIT_2 = 2
+    CLAN_BATTLE_SUPPORT_UNIT_1 = 3
+    CLAN_BATTLE_SUPPORT_UNIT_2 = 4
+

--- a/autopcr/model/enums.py
+++ b/autopcr/model/enums.py
@@ -259,6 +259,39 @@ class eMissionStatusType(Enum):
     AlreadyReceive = 2
     ChallengePeriodEnd = 101
     INVALID_VALUE = -1
+class eMissionCategory(Enum):
+    PLAYERLV = 101
+    CLEARRANK = 102
+    RANK = 103
+    TUTORIAL = 104
+    LINK = 105
+    LOGIN = 106
+    VOTE = 107
+    FRIEND = 108
+    FRIEND_BATTLE = 109
+    EMBLEM = 110
+    QUEST = 200
+    MAINQUEST = 201
+    TRAINING_QUEST = 202
+    DUNGEON = 204
+    ARENA = 205
+    BALENA = 206
+    PALENA = 207
+    TOWER = 208
+    UNIT_EXPAND = 209
+    CHARA = 301
+    REINFORCE = 302
+    SKILL = 303
+    EQUIPMENT = 304
+    ROOM = 305
+    GACHA = 401
+    SHOP = 402
+    JEWEL_BUY = 403
+    GOLD_BUY = 404
+    BUY = 405
+    CLAN = 501
+    EVENT = 601
+    STORY = 602
 class eSrtCatalogStatus(Enum):
     EnemyUnlock = 1
     EnemyReaded = 2
@@ -454,3 +487,15 @@ class eClanSupportMemberType(Enum):
     CLAN_BATTLE_SUPPORT_UNIT_1 = 3
     CLAN_BATTLE_SUPPORT_UNIT_2 = 4
 
+class eSkillLocationCategory(Enum):
+    NO_SKILLSLOT = 0
+    UNION_BURST_SKILL = 101
+    MAIN_SKILL_1 = 201
+    MAIN_SKILL_2 = 202
+    EX_SKILL_1 = 301
+    EX_SKILL_2 = 302
+    EX_SKILL_3 = 303
+    FREE_SKILL_1 = 401
+    FREE_SKILL_2 = 402
+    FREE_SKILL_3 = 403
+    INVALID_VALUE = -1

--- a/autopcr/model/enums.py
+++ b/autopcr/model/enums.py
@@ -309,8 +309,12 @@ class ePromotionLevel(Enum):
     Green1 = 21
     Green2 = 22
     Green3 = 23
-    Green4 = 24
+    Orange1 = 24
+    Orange2 = 25
+    Orange3 = 26
+    Orange4 = 27
     INVALID_VALUE = -1
+
 class eClanChatPlayButtonCondition(Enum):
     NONE = 0
     UNOPENED_MINI_GAME_IN_EVENT = 1
@@ -424,12 +428,6 @@ class ePeriod(Enum):
 
 class eEventType(Enum):
     HATSUNE = 1
-    INVALID_VALUE = -1
-
-class eEventSubStoryStatus(Enum):
-    UNREAD = 1
-    READED = 2
-    ADDED = 3
     INVALID_VALUE = -1
 
 class eBattleLogType(Enum):

--- a/autopcr/model/enums.py
+++ b/autopcr/model/enums.py
@@ -416,3 +416,35 @@ class eGachaDrawType(Enum):
     SpecialTicket = 9
     SpFesCmapaign10Shot = 10
     INVALID_VALUE = -1
+
+class ePeriod(Enum):
+    NONE = 0
+    LOGIN_PERIOD = 1
+    ANNIVERSARY_PERIOD = 2
+
+class eEventType(Enum):
+    HATSUNE = 1
+    INVALID_VALUE = -1
+
+class eEventSubStoryStatus(Enum):
+    UNREAD = 1
+    READED = 2
+    ADDED = 3
+    INVALID_VALUE = -1
+
+class eBattleLogType(Enum):
+	MISS = 1
+	SET_DAMAGE = 2
+	SET_ABNORMAL = 3
+	SET_RECOVERY = 4
+	SET_BUFF_DEBUFF = 5
+	SET_STATE = 6
+	BUTTON_TAP = 7
+	SET_ENERGY = 8
+	DAMAGE_CHARGE = 9
+	GIVE_VALUE_ADDITIONAL = 10
+	GIVE_VALUE_MULTIPLY = 11
+	WAVE_END_HP = 12
+	WAVE_END_DAMAGE_AMOUNT = 13
+	BREAK = 14
+	INVALID_VALUE = -1

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -251,6 +251,7 @@ class LoadIndexResponse(responses.LoadIndexResponse):
         mgr.deck_list = {deck.deck_number:deck for deck in self.deck_list}
         mgr.campaign_list = self.campaign_list
         mgr.gacha_point = {gacha.exchange_id: gacha for gacha in self.gacha_point_info_list}
+        mgr.dispatch_units = self.dispatch_units
 
 
 @handles

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -15,6 +15,31 @@ class SourceIniGetMaintenanceStatusResponse(sdkrequests.SourceIniGetMaintenanceS
             await mgr.try_update_database(int(self.manifest_ver))
 
 @handles
+class SkillLevelUpResponse(responses.SkillLevelUpResponse):
+    async def update(self, mgr: datamgr, request):
+        mgr.unit[self.unit_data.id] = self.unit_data
+
+@handles
+class UnitFreeLevelUpResponse(responses.UnitFreeLevelUpResponse):
+    async def update(self, mgr: datamgr, request):
+        mgr.unit[self.unit_data.id] = self.unit_data
+
+@handles
+class UnitFreePromotionResponse(responses.UnitFreePromotionResponse):
+    async def update(self, mgr: datamgr, request):
+        mgr.unit[self.unit_data.id] = self.unit_data
+
+@handles
+class UnitFreeEquipResponse(responses.UnitFreeEquipResponse):
+    async def update(self, mgr: datamgr, request):
+        mgr.unit[self.unit_data.id] = self.unit_data
+
+@handles
+class EquipmentFreeEnhanceResponse(responses.EquipmentFreeEnhanceResponse):
+    async def update(self, mgr: datamgr, request):
+        mgr.unit[self.unit_data.id] = self.unit_data
+
+@handles
 class ShioriQuestSkipResponse(responses.ShioriQuestSkipResponse):
     async def update(self, mgr: datamgr, request):
         if self.quest_result_list:
@@ -206,6 +231,11 @@ class PresentReceiveAllResponse(responses.PresentReceiveAllResponse):
 
 
 @handles
+class MissionIndexResponse(responses.MissionIndexResponse):
+    async def update(self, mgr: datamgr, request):
+        mgr.missions = self.missions
+
+@handles
 class MissionAcceptResponse(responses.MissionAcceptResponse):
     async def update(self, mgr: datamgr, request):
         if self.rewards:
@@ -241,6 +271,7 @@ class LoadIndexResponse(responses.LoadIndexResponse):
             mgr.unit = {unit.id: unit for unit in self.unit_list}
         if self.user_chara_info:
             mgr.unit_love_data = {unit.chara_id: unit for unit in self.user_chara_info}
+        mgr.growth_unit = {unit.unit_id: unit for unit in self.growth_unit_list}
         mgr.stamina = self.user_info.user_stamina
         mgr.settings = self.ini_setting
         mgr.recover_stamina_exec_count = self.shop.recover_stamina.exec_count
@@ -265,6 +296,7 @@ class HomeIndexResponse(responses.HomeIndexResponse):
         mgr.training_quest_max_count = self.training_quest_max_count
         mgr.quest_dict = {q.quest_id: q for q in self.quest_list}
         shiori_dict = {q.quest_id: q for q in self.shiori_quest_info.quest_list} if self.shiori_quest_info else {}
+        mgr.missions = self.missions
         mgr.quest_dict.update(shiori_dict)
 
         if self.dungeon_info.dungeon_area:

--- a/autopcr/model/responses.py
+++ b/autopcr/model/responses.py
@@ -260,6 +260,7 @@ class ClanInfoResponse(ResponseBase):
 	clan_status: eUserClanJoinStatus = None
 	user_equip: List[InventoryInfoShort] = None
 	have_join_request: int = None
+	have_new_equip_donation: int = None
 	unread_liked_count: int = None
 	is_equip_request_finish_checked: int = None
 	add_present_count: int = None

--- a/autopcr/module/modulemgr.py
+++ b/autopcr/module/modulemgr.py
@@ -11,14 +11,15 @@ class ModuleManager:
     _modules: List[type] = []
 
     def __init__(self, config, parent):
-        from .modules import daily_modules, tool_modules, cron_modules
+        from .modules import daily_modules, tool_modules, cron_modules, hidden_modules
         from .accountmgr import Account
 
         self.parent: Account = parent
         self.cron_modules: List[Module] = [m(self) for m in cron_modules]
         self.daily_modules: List[Module] = [m(self) for m in daily_modules]
         self.tool_modules: List[Module] = [m(self) for m in tool_modules]
-        self.name_to_modules: Dict[str, Module] = {m.key: m for m in (self.daily_modules + self.tool_modules)}
+        self.hidden_modules: List[Module] = [m(self) for m in hidden_modules]
+        self.name_to_modules: Dict[str, Module] = {m.key: m for m in (self.daily_modules + self.tool_modules + self.hidden_modules)}
         self.client = self.parent.get_client()
         self._crons = []
         self._load_config(config)

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -63,6 +63,7 @@ daily_modules = [
     jjc_shop,
     pjjc_shop,
     
+    clan_equip_request,
     love_up,
     main_story_reading,
     tower_story_reading,

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -79,6 +79,7 @@ hidden_modules = [
 ]
 
 tool_modules = [
+    jjc_back,
     get_clan_support_unit,
     get_library_import_data,
     get_need_equip,

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -79,6 +79,7 @@ hidden_modules = [
 ]
 
 tool_modules = [
+    get_clan_support_unit,
     get_library_import_data,
     get_need_equip,
     get_need_memory,

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -10,6 +10,7 @@ from .story import *
 from .sweep import *
 from .tower import *
 from .tools import *
+from .unit import *
 
 cron_modules = [
     cron1,
@@ -55,6 +56,9 @@ daily_modules = [
 
     jjc_daily,
     pjjc_daily,
+    unit_equip_enhance_up,
+    unit_skill_level_up,
+
     mission_receive_last,
 
     normal_shop,

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -71,6 +71,10 @@ daily_modules = [
     user_info,
 ]
 
+hidden_modules = [
+    gacha_start
+]
+
 tool_modules = [
     get_library_import_data,
     get_need_equip,

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -53,6 +53,8 @@ daily_modules = [
     hatsune_gacha_exchange,
     hatsune_mission_accept2,
 
+    jjc_daily,
+    pjjc_daily,
     mission_receive_last,
 
     normal_shop,

--- a/autopcr/module/modules/autosweep.py
+++ b/autopcr/module/modules/autosweep.py
@@ -114,7 +114,7 @@ class smart_hard_sweep(Module):
                         resp = await client.quest_skip_aware(quest.quest_id, max_times)
                         clean_cnt[quest.quest_id] += max_times
                         tmp.extend([item for item in resp if (item.type, item.id) == token]) 
-                    except SkipError:
+                    except SkipError as e:
                         pass
                     except AbortError as e:
                         stop = True
@@ -135,6 +135,8 @@ class smart_hard_sweep(Module):
                 self._log("---------")
             if tmp:
                 self._log(await client.serlize_reward(tmp))
+            if not self.log:
+                self._log("需刷取的碎片图均无次数")
 
 @singlechoice("vh_sweep_campaign_times", "庆典次数", 3, [0, 3, 6])
 @singlechoice("vh_sweep_times", "非庆典次数", 3, [0, 3, 6])

--- a/autopcr/module/modules/clan.py
+++ b/autopcr/module/modules/clan.py
@@ -23,3 +23,36 @@ class clan_like(Module):
         await client.clan_like(rnd[0])
         self._log(f"为【{rnd[1]}】点赞")
 
+@description('对某颜色缺口数量最多的装备发起请求')
+@name("装备请求")
+@singlechoice("clan_equip_request_color", "装备颜色", "all", ["all", "Silver", "Gold", "Purple", 'Red', 'Green'])
+@singlechoice("clan_equip_request_consider_unit", "需求角色", "all", ["all", 'favorite'])
+@default(False)
+class clan_equip_request(Module):
+    async def do_task(self, client: pcrclient):
+        clan = await client.get_clan_info()
+        if not clan:
+            raise AbortError("未加入公会")
+
+        if clan.have_new_equip_donation:
+            res = await client.equip_get_request(clan.clan.detail.clan_id, 0)
+            self._log(f"收到{db.get_inventory_name_san((eInventoryType.Equip, res.request.equip_id))}x{res.receive_donation_sum}：" + ' '.join(f"{user.name}x{user.num}" for user in res.request.history))
+            clan.is_equip_request_finish_checked = 1
+
+        if not clan.is_equip_request_finish_checked:
+            raise AbortError("当前请求尚未结束")
+
+        fav = (self.get_config('clan_equip_request_consider_unit') == 'favorite')
+        demand = client.data.get_equip_demand_gap(like_unit_only=fav)
+        config_color: str = self.get_config('clan_equip_request_color')
+        target_level = set(level for color, level in vars(ePromotionLevel).items() if color.startswith(config_color))
+
+        consider_equip = [(equip_id, num) for (item_type, equip_id), num in demand.items() if db.equip_data[equip_id].enable_donation and (db.equip_data[equip_id].promotion_level in target_level or config_color == 'all')]
+        consider_equip = sorted(consider_equip, key=lambda x: x[1], reverse=True)
+
+        if consider_equip:
+            (equip_id, num) = consider_equip[0]
+            await client.request_equip(equip_id, clan.clan.detail.clan_id)
+            self._log(f"请求【{db.get_inventory_name_san((eInventoryType.Equip, equip_id))}】装备，缺口数量为{num}")
+        else:
+            raise AbortError("没有可请求的装备")

--- a/autopcr/module/modules/clan.py
+++ b/autopcr/module/modules/clan.py
@@ -48,7 +48,7 @@ class clan_equip_request(Module):
             raise SkipError("当前请求尚未结束")
         elif clan.latest_request_time:
             res = await client.equip_get_request(clan.clan.detail.clan_id, 0)
-            msg = f"收到{db.get_inventory_name_san((eInventoryType.Equip, res.request.equip_id))}x{res.request.donation_num}：" + ' '.join(f"{user.name}x{user.num}" for user in res.request.history)
+            msg = f"收到{db.get_equip_name(res.request.equip_id)}x{res.request.donation_num}：" + ' '.join(f"{user.name}x{user.num}" for user in res.request.history)
             self._log(msg.strip("："))
 
         fav = (self.get_config('clan_equip_request_consider_unit') == 'favorite')
@@ -62,6 +62,6 @@ class clan_equip_request(Module):
         if consider_equip:
             (equip_id, num) = consider_equip[0]
             await client.request_equip(equip_id, clan.clan.detail.clan_id)
-            self._log(f"请求【{db.get_inventory_name_san((eInventoryType.Equip, equip_id))}】装备，缺口数量为{num}")
+            self._log(f"请求【{db.get_equip_name(equip_id)}】装备，缺口数量为{num}")
         else:
             raise AbortError("没有可请求的装备")

--- a/autopcr/module/modules/clan.py
+++ b/autopcr/module/modules/clan.py
@@ -4,6 +4,7 @@ from ...core.pcrclient import pcrclient
 from ...model.error import *
 from ...model.enums import *
 import random
+from ...db.database import db
 
 @description('在公会中自动随机选择一位成员点赞。')
 @name("公会点赞")
@@ -12,9 +13,10 @@ class clan_like(Module):
     async def do_task(self, client: pcrclient):
         if client.data.clan_like_count:
             raise SkipError('今日点赞次数已用完。')
-        info = await client.get_clan_info()
-        if not info:
+        clan = await client.get_clan_info()
+        if not clan:
             raise AbortError("未加入公会")
+        info = clan.clan
         members = [(x.viewer_id, x.name) for x in info.members if x.viewer_id != client.viewer_id]
         if len(members) == 0: raise AbortError("No other members in clan")
         rnd = random.choice(members)

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -4,6 +4,8 @@ from ...core.pcrclient import pcrclient
 from ...model.error import *
 from ...db.database import db
 from ...model.enums import *
+from ...util.questutils import *
+import asyncio
 import datetime
 
 @description('全局生效，优先级n4>n3>h3>n2>h2')
@@ -111,6 +113,62 @@ class jjc_reward(Module):
         if info.reward_info.count:
             await client.receive_grand_arena_reward()
         self._log(f"pjjc币x{info.reward_info.count}")
+
+@description('仅进攻，不结算，会消耗次数')
+@name('完成每日jjc任务')
+@default(False)
+class jjc_daily(Module):
+    async def do_task(self, client: pcrclient):
+        if client.data.is_empty_deck(ePartyType.ARENA):
+            raise AbortError("未设置进攻队伍，请设置") # AUTO SET TODO
+
+        info = await client.get_arena_info()
+        if info.arena_info.battle_number != info.arena_info.max_battle_number:
+            raise SkipError("今日jjc任务已完成")
+
+        for _ in range(3):
+            if info.search_opponent: break
+            await asyncio.sleep(2)
+            info = await client.get_arena_info()
+
+        if not info.search_opponent:
+            raise AbortError("无法搜到可攻击对手，请稍后再试")
+        opponent = info.search_opponent[0]
+        await client.arena_apply(opponent.viewer_id, opponent.rank)
+        token = create_battle_start_token()
+        await client.arena_start(token, opponent.viewer_id, info.arena_info.battle_number, 1)
+        await client.logout()
+        await asyncio.sleep(2)
+        self._log(f"当前排名{info.arena_info.rank}，进攻第{opponent.rank}名的【{opponent.user_name}】")
+
+@description('仅进攻，不结算，会消耗次数')
+@name('完成每日pjjc任务')
+@default(False)
+class pjjc_daily(Module):
+    async def do_task(self, client: pcrclient):
+        if client.data.is_empty_deck(ePartyType.GRAND_ARENA_1) or \
+        client.data.is_empty_deck(ePartyType.GRAND_ARENA_2) or \
+        client.data.is_empty_deck(ePartyType.GRAND_ARENA_3):
+            raise AbortError("未设置进攻队伍，请设置") # AUTO SET TODO
+
+        info = await client.get_grand_arena_info()
+        if info.grand_arena_info.battle_number != info.grand_arena_info.max_battle_number:
+            raise SkipError("今日pjjc任务已完成")
+
+        for _ in range(3):
+            if info.search_opponent: break
+            await asyncio.sleep(2)
+            info = await client.get_grand_arena_info()
+
+        if not info.search_opponent:
+            raise AbortError("无法搜到可攻击对手，请稍后再试")
+        opponent = info.search_opponent[0]
+        await client.grand_arena_apply(opponent.viewer_id, opponent.rank)
+        token = create_battle_start_token()
+        await client.grand_arena_start(token, opponent.viewer_id, info.grand_arena_info.battle_number, 1)
+        await client.logout()
+        await asyncio.sleep(2)
+        self._log(f"当前排名{info.grand_arena_info.rank}，进攻第{opponent.rank}名的【{opponent.user_name}】")
 
 @description('展示基本信息')
 @name('基本信息')

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -176,7 +176,7 @@ class pjjc_daily(Module):
 class user_info(Module):
     async def do_task(self, client: pcrclient):
         now = db.format_time(datetime.datetime.now())
-        self._log(f"{client.data.name} 体力{client.data.stamina}({db.team_max_stamina[client.data.team_level].max_stamina}) 等级{client.data.team_level} 钻石{client.data.jewel.free_jewel} mana{client.data.gold.gold_id_free} 扫荡券{client.data.get_inventory((eInventoryType.Item, 23001))} 母猪石{client.data.get_inventory((eInventoryType.Item, 90005))}")
+        self._log(f"{client.data.name} 体力{client.data.stamina}({db.team_info[client.data.team_level].max_stamina}) 等级{client.data.team_level} 钻石{client.data.jewel.free_jewel} mana{client.data.gold.gold_id_free} 扫荡券{client.data.get_inventory((eInventoryType.Item, 23001))} 母猪石{client.data.get_inventory((eInventoryType.Item, 90005))}")
         self._log(f"已购买体力数：{client.data.recover_stamina_exec_count}")
         self._log(f"清日常时间:{now}")
 

--- a/autopcr/module/modules/room.py
+++ b/autopcr/module/modules/room.py
@@ -37,7 +37,7 @@ class room_upper_all(Module):
         for x in room.user_room_item_list:
             if db.is_room_item_level_upable(client.data.team_level, x):
                 await client.room_level_up_item(floors[x.serial_id], x)
-                self._log(f"开始升级{db.get_inventory_name_san((eInventoryType.RoomItem, x.room_item_id))}至{x.room_item_level + 1}级")
+                self._log(f"开始升级{db.get_room_item_name(x.room_item_id)}至{x.room_item_level + 1}级")
 
         if not self.log:
             raise SkipError('没有可升级的家园物品。')
@@ -84,7 +84,7 @@ class love_up(Module):
     async def do_task(self, client: pcrclient):
         for unit in client.data.unit_love_data.values():
             unit_id = unit.chara_id * 100 + 1
-            unit_name = db.get_inventory_name_san((eInventoryType.Unit, unit_id))
+            unit_name = db.get_unit_name(unit_id)
             love_level, total_love = db.max_total_love(client.data.unit[unit_id].unit_rarity)
             if unit.chara_love < total_love:
                 dis = total_love - unit.chara_love

--- a/autopcr/module/modules/room.py
+++ b/autopcr/module/modules/room.py
@@ -58,7 +58,7 @@ class room_like_back(Module):
         while pos < like_history.today_be_liked_count or cnt < 10:
             viewer_id = 0
             if pos < like_history.today_be_liked_count:
-                viewer_id = like_history.like_history[pos].viewer_id
+                viewer_id = like_history.be_liked_history[pos].viewer_id
             user = await client.room_visit(viewer_id)
             pos += 1
             if user.room_user_info.today_like_flag:

--- a/autopcr/module/modules/shop.py
+++ b/autopcr/module/modules/shop.py
@@ -114,8 +114,8 @@ class normal_shop(shop_buyer):
 @name('限定商店购买')
 @default(False)
 class limit_shop(shop_buyer):
-    def _exp_count(self, client: pcrclient): return 99999 if "经验药水" in self.get_config('limit_shop_buy_kind') else 0
-    def _equip_count(self, client: pcrclient): return 9999 if "装备" in self.get_config('limit_shop_buy_kind') else 0
+    def _exp_count(self, client: pcrclient): return 99000 if "经验药水" in self.get_config('limit_shop_buy_kind') else 0
+    def _equip_count(self, client: pcrclient): return 9900 if "装备" in self.get_config('limit_shop_buy_kind') else 0
     def coin_limit(self) -> int: return self.get_config('limit_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.LIMITED_SHOP
     def reset_count(self) -> int: return 0

--- a/autopcr/module/modules/tools.py
+++ b/autopcr/module/modules/tools.py
@@ -67,7 +67,7 @@ class get_clan_support_unit(Module):
                 strongest, info = await client.serialize_unit_info(client.data.unit[unit.unit_id])
                 msg.append((unit.unit_id, strongest, client.name, info))
 
-        msg = sorted(msg, key=lambda x:(x[0], x[1]))
+        msg = sorted(msg, key=lambda x:(x[0], -x[1]))
         for unit_id, strongest, owner_name, unit_info in msg:
             unit_name = db.get_inventory_name_san((eInventoryType.Unit, unit_id))
             info = f'{unit_name}({owner_name}): {"满中满" if strongest else "非满警告！"}\n{unit_info}\n'

--- a/autopcr/module/modules/tools.py
+++ b/autopcr/module/modules/tools.py
@@ -21,6 +21,8 @@ class gacha_start(Module):
         return any(item.id in r for item in new)
 
     async def do_task(self, client: pcrclient):
+        if ':' not in self.get_config('pool_id'):
+            raise ValueError("配置格式不正确")
         gacha_id = int(self.get_config('pool_id').split(':')[0])
         resp = await client.get_gacha_index()
         for gacha in resp.gacha_info:
@@ -37,8 +39,8 @@ class gacha_start(Module):
         cnt = 0
         try:
             while True:
-                cnt += 1
                 reward += await client.exec_gacha_aware(target_gacha, 10, eGachaDrawType.Payment, client.data.jewel.free_jewel + client.data.jewel.jewel, 0)
+                cnt += 1
                 if not always or self.can_stop(reward.new_unit, db.gacha_exchange_chara[target_gacha.exchange_id]) :
                     break
         except:

--- a/autopcr/module/modules/tools.py
+++ b/autopcr/module/modules/tools.py
@@ -50,6 +50,29 @@ class gacha_start(Module):
             self._log(await client.serlize_gacha_reward(reward))
             self._log(f"当前pt为{client.data.gacha_point[target_gacha.exchange_id].current_point}")
 
+@description('查看会战支援角色的详细数据，拒绝内鬼！')
+@name('会战支援数据')
+@default(True)
+class get_clan_support_unit(Module):
+    async def do_task(self, client: pcrclient):
+        await client.get_clan_battle_top(client.data.clan, 1, client.data.get_shop_gold(eSystemId.CLAN_BATTLE_SHOP))
+        unit_list = await client.get_clan_battle_support_unit_list(client.data.clan)
+        msg = []
+        for unit in unit_list.support_unit_list:
+            strongest, info = await client.serialize_unit_info(unit.unit_data)
+            msg.append((unit.unit_data.id, strongest, unit.owner_name, info))
+
+        for unit in client.data.dispatch_units:
+            if unit.position == eClanSupportMemberType.CLAN_BATTLE_SUPPORT_UNIT_1 or unit.position == eClanSupportMemberType.CLAN_BATTLE_SUPPORT_UNIT_2:
+                strongest, info = await client.serialize_unit_info(client.data.unit[unit.unit_id])
+                msg.append((unit.unit_id, strongest, client.name, info))
+
+        msg = sorted(msg, key=lambda x:(x[0], x[1]))
+        for unit_id, strongest, owner_name, unit_info in msg:
+            unit_name = db.get_inventory_name_san((eInventoryType.Unit, unit_id))
+            info = f'{unit_name}({owner_name}): {"满中满" if strongest else "非满警告！"}\n{unit_info}\n'
+            self._log(info)
+
 @description('获得可导入到兰德索尔图书馆的账号数据')
 @name('兰德索尔图书馆导入数据')
 @default(True)

--- a/autopcr/module/modules/tools.py
+++ b/autopcr/module/modules/tools.py
@@ -69,7 +69,7 @@ class get_clan_support_unit(Module):
 
         msg = sorted(msg, key=lambda x:(x[0], -x[1]))
         for unit_id, strongest, owner_name, unit_info in msg:
-            unit_name = db.get_inventory_name_san((eInventoryType.Unit, unit_id))
+            unit_name = db.get_unit_name(unit_id)
             info = f'{unit_name}({owner_name}): {"满中满" if strongest else "非满警告！"}\n{unit_info}\n'
             self._log(info)
 

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -7,7 +7,7 @@ from ...db.models import GrowthParameter
 from ...model.enums import *
 from ...model.common import SkillLevelInfo, SkillLevelUpDetail, UnitData
 
-class unit_controller(Module):
+class UnitController(Module):
 
     async def is_growth_unit(self, unit_id: int, client: pcrclient) -> Union[GrowthParameter, None]:
         unit_name = db.get_unit_name(unit_id)
@@ -97,7 +97,7 @@ class unit_controller(Module):
 @name('完成装备强化任务')
 @singlechoice("equip_enhance_up_unit", "强化角色", "100101:日和莉", [f"{unit}:{db.unit_data[unit].unit_name}" for unit in db.unit_data])
 @default(False)
-class unit_equip_enhance_up(unit_controller):
+class unit_equip_enhance_up(UnitController):
     async def do_task(self, client: pcrclient):
         if client.data.is_mission_finished(eSystemId.UNIT_EQUIP_ENHANCE):
             raise SkipError("今日已完成装备强化任务")
@@ -128,7 +128,7 @@ class unit_equip_enhance_up(unit_controller):
 @name('完成技能升级任务')
 @singlechoice("level_up_unit", "强化角色", "100101:日和莉", [f"{unit}:{db.unit_data[unit].unit_name}" for unit in db.unit_data])
 @default(False)
-class unit_skill_level_up(unit_controller):
+class unit_skill_level_up(UnitController):
     async def do_task(self, client: pcrclient):
         if client.data.is_mission_finished(eSystemId.UNIT_SKILL_LVUP):
             raise SkipError("今日已完成技能升级任务")

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -1,0 +1,156 @@
+from ..modulebase import *
+from ..config import *
+from ...core.pcrclient import pcrclient
+from ...model.error import *
+from ...db.database import db
+from ...db.models import GrowthParameter
+from ...model.enums import *
+from ...model.common import SkillLevelInfo, SkillLevelUpDetail, UnitData
+
+class unit_controller(Module):
+
+    async def is_growth_unit(self, unit_id: int, client: pcrclient) -> Union[GrowthParameter, None]:
+        unit_name = db.get_unit_name(unit_id)
+        if unit_id not in client.data.unit:
+            raise AbortError(f"未解锁角色{unit_name}")
+        if unit_id not in client.data.growth_unit:
+            return None
+        growth_id = list(set(client.data.growth_unit[unit_id].growth_parameter_list.growth_id_list) & set(db.growth_parameter.keys())) # len should 1
+        if len(growth_id) != 1:
+            raise ValueError("未知的光辉球类型" + ','.join(map(str, growth_id)))
+        growth_limit = db.growth_parameter[growth_id[0]]
+        return growth_limit
+
+    async def unit_skill_up(self, unit_id: int, location: int, step: int, current_level: int, free: bool, client: pcrclient):
+        if free:
+            self._log(f"角色【{db.get_unit_name(unit_id)}】技能{location}升至{current_level + step}级")
+            skill_level_up_detail = SkillLevelUpDetail()
+            skill_level_up_detail.location = location
+            skill_level_up_detail.step = step
+            skill_level_up_detail.current_level = current_level
+            await client.skill_level_up(unit_id, [skill_level_up_detail])
+        else:
+            raise ValueError("暂不支持非免费品级提升")
+
+    async def unit_skill_up_aware(self, unit: UnitData, location: int, skill: SkillLevelInfo, target_skill_level: int, client: pcrclient, limit: GrowthParameter = None):
+        if limit:
+            if limit.skill_level < target_skill_level:
+                raise AbortError(f"{db.get_unit_name(unit.id)}技能{location}不支持免费强化至{target_skill_level}级(至多{limit.skill_level})")
+
+        if target_skill_level > unit.unit_level:
+            await self.unit_level_up_aware(unit, target_skill_level, client, limit)
+
+        await self.unit_skill_up(unit.id, location, target_skill_level - skill.skill_level, skill.skill_level, limit is not None, client)
+
+    async def unit_promotion_up(self, unit_id: int, target_promotion_level: int, free: bool, client: pcrclient):
+        if free:
+            self._log(f"角色【{db.get_unit_name(unit_id)}】升至品级{target_promotion_level}")
+            await client.unit_free_promotion(unit_id, target_promotion_level)
+        else:
+            raise ValueError("暂不支持非免费品级提升")
+
+    async def unit_promotion_up_aware(self, unit: UnitData, target_promotion_level: int, client: pcrclient, limit: GrowthParameter):
+        if limit:
+            if target_promotion_level > limit.promotion_level:
+                raise AbortError(f"目标品级{target_promotion_level}超过了免费可提升品级{limit.promotion_level}")
+        await self.unit_promotion_up(unit.id, target_promotion_level, limit is not None, client)
+
+    async def unit_level_up(self, unit_id: int, target_level: int, free: bool, client: pcrclient):
+        if free:
+            self._log(f"角色【{db.get_unit_name(unit_id)}】升至{target_level}级")
+            await client.unit_free_level_up(unit_id, target_level)
+        else:
+            raise ValueError("暂不支持非免费等级提升")
+
+    async def unit_level_up_aware(self, unit: UnitData, target_level: int, client: pcrclient, limit: GrowthParameter = None):
+        if limit:
+            if target_level > limit.unit_level:
+                raise AbortError(f"角色{db.get_unit_name(unit.id)}的目标等级{target_level}超过了免费可提升等级{limit.unit_level}")
+        await self.unit_level_up(unit.id, target_level, limit is not None, client)
+
+    async def unit_equip_slot(self, unit_id: int, equip_id: int, slot_num: int, free: bool, client: pcrclient):
+        if free:
+            self._log(f"为角色【{db.get_unit_name(unit_id)}】装备{db.get_equip_name(equip_id)}")
+            await client.unit_free_equip(unit_id, [slot_num])
+        else:
+            raise ValueError("暂不支持非免费装备装备")
+
+    async def unit_equip_slot_aware(self, unit: UnitData, equip_id: int, slot_num: int, client: pcrclient, limit: GrowthParameter = None):
+        if limit:
+            if limit.promotion_level <= unit.promotion_level and getattr(limit, f"equipment_{slot_num}") == -1:
+                raise AbortError(f"{db.get_unit_name(unit.id)}品级{unit.promotion_level}的{slot_num}位装备{db.get_equip_name(equip_id)}不支持免费装备")
+
+        if db.equip_data[equip_id].require_level > unit.unit_level:
+            self._log(f"为角色{db.get_unit_name(unit.id)}装备{db.get_equip_name(equip_id)}需要升至{db.equip_data[equip_id].require_level}级")
+            await self.unit_level_up_aware(unit, db.equip_data[equip_id].require_level, client, limit)
+
+        await self.unit_equip_slot(unit.id, equip_id, slot_num, limit is not None, client)
+
+    async def unit_equip_enhance(self, unit: UnitData, equip_id: int, slot_num: int, enhancement_level: int, free: bool, client: pcrclient):
+        if free:
+            self._log(f"角色【{db.get_unit_name(unit.id)}】{slot_num}位上装备{db.get_equip_name(equip_id)}强化至{enhancement_level}星级")
+            await client.equipment_free_enhance(unit.id, slot_num, enhancement_level)
+        else:
+            raise ValueError("暂不支持非免费装备强化")
+
+@description('仅支持光辉球角色')
+@name('完成装备强化任务')
+@singlechoice("equip_enhance_up_unit", "强化角色", "100101:日和莉", [f"{unit}:{db.unit_data[unit].unit_name}" for unit in db.unit_data])
+@default(False)
+class unit_equip_enhance_up(unit_controller):
+    async def do_task(self, client: pcrclient):
+        if client.data.is_mission_finished(eSystemId.UNIT_EQUIP_ENHANCE):
+            raise SkipError("今日已完成装备强化任务")
+
+        unit_id, unit_name = self.get_config('equip_enhance_up_unit').split(':')
+        unit_id = int(unit_id)
+        growth_limit = await self.is_growth_unit(unit_id, client)
+        if not growth_limit:
+            raise AbortError(f"非光辉球使用角色【{unit_name}】")
+
+        stop = False
+        while not stop:
+            for id, equip in enumerate(client.data.unit[unit_id].equip_slot):
+                slot_num = id + 1
+                if not equip.is_slot:
+                    await self.unit_equip_slot_aware(client.data.unit[unit_id], equip.id, slot_num, client, growth_limit)
+
+                equip_promotion_level = db.equip_data[equip.id].promotion_level
+                if equip_promotion_level in db.equipment_enhance_data and equip.enhancement_level < max(db.equipment_enhance_data[equip_promotion_level].keys()):
+                    await self.unit_equip_enhance(client.data.unit[unit_id], equip.id, slot_num, equip.enhancement_level + 1, growth_limit is not None, client)
+                    stop = True
+                    break
+            else:
+                self._log(f"所有装备均已满强化，需提升角色品级")
+                await self.unit_promotion_up_aware(client.data.unit[unit_id], client.data.unit[unit_id].promotion_level + 1, client, growth_limit)
+
+@description('仅支持光辉球角色')
+@name('完成技能升级任务')
+@singlechoice("level_up_unit", "强化角色", "100101:日和莉", [f"{unit}:{db.unit_data[unit].unit_name}" for unit in db.unit_data])
+@default(False)
+class unit_skill_level_up(unit_controller):
+    async def do_task(self, client: pcrclient):
+        if client.data.is_mission_finished(eSystemId.UNIT_SKILL_LVUP):
+            raise SkipError("今日已完成技能升级任务")
+
+        unit_id, unit_name = self.get_config('level_up_unit').split(':')
+        unit_id = int(unit_id)
+        growth_limit = await self.is_growth_unit(unit_id, client)
+        if not growth_limit:
+            raise AbortError(f"非光辉球使用角色【{unit_name}】")
+
+        stop = False
+
+        while not stop:
+            skills = [(eSkillLocationCategory.UNION_BURST_SKILL + id, skill) for id, skill in enumerate(client.data.unit[unit_id].union_burst)] +  \
+                    [(eSkillLocationCategory.MAIN_SKILL_1 + id, skill) for id, skill in enumerate(client.data.unit[unit_id].main_skill)] +  \
+                    [(eSkillLocationCategory.EX_SKILL_1 + id, skill) for id, skill in enumerate(client.data.unit[unit_id].ex_skill)]
+
+            for pos, skill in skills:
+                if skill.skill_level < client.data.unit[unit_id].unit_level and skill.skill_level < growth_limit.skill_level:
+                    await self.unit_skill_up_aware(client.data.unit[unit_id], pos, skill, skill.skill_level + 1, client, growth_limit)
+                    stop = True
+                    break
+            else:
+                self._log(f"所有技能均等于角色等级{client.data.unit[unit_id].unit_level}级，需提升角色等级")
+                await self.unit_level_up_aware(client.data.unit[unit_id], client.data.unit[unit_id].unit_level + 1, client, growth_limit)

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -30,7 +30,7 @@ class unit_controller(Module):
             skill_level_up_detail.current_level = current_level
             await client.skill_level_up(unit_id, [skill_level_up_detail])
         else:
-            raise ValueError("暂不支持非免费品级提升")
+            raise ValueError("暂不支持非免费技能提升")
 
     async def unit_skill_up_aware(self, unit: UnitData, location: int, skill: SkillLevelInfo, target_skill_level: int, client: pcrclient, limit: GrowthParameter = None):
         if limit:

--- a/autopcr/util/questutils.py
+++ b/autopcr/util/questutils.py
@@ -1,4 +1,10 @@
-import random
+import uuid
 
 def create_quest_token(): 
-    return f'{random.randint(0, 1<<64):16x}'
+    return create_battle_start_token()
+    # return f'{random.randint(0, 1<<64):16x}'
+
+def create_battle_start_token():
+    unique_id = uuid.uuid4()
+    token = unique_id.hex[:16]
+    return token

--- a/server.py
+++ b/server.py
@@ -43,6 +43,7 @@ sv_help = f"""
 [{prefix}查记忆碎片 [昵称] [可刷取]] 查询缺口记忆碎片，可刷取只仅查看h图可刷的碎片
 [{prefix}查装备 [昵称] [rank] [fav]] 查询缺口装备，[rank]为数字，只查询>=rank的角色缺口装备，fav表示只查询favorite的角色
 [{prefix}刷图推荐 [昵称] [rank] [fav]] 查询缺口装备的刷图推荐，格式同上
+[{prefix}公会支援] 查询公会支援角色配置
 """
 
 if address is None:

--- a/server.py
+++ b/server.py
@@ -18,7 +18,7 @@ from hoshino.config import SUPERUSERS
 from hoshino.util import escape
 from hoshino.typing import CQEvent, MessageSegment
 from ._util import get_result
-from ._task import DailyClean, FindEquip, FindMemory, FindXinsui, Task, GetLibraryImport, QuestRecommand, Gacha, ClanBattleSupport
+from ._task import *
 import datetime
 import random
 
@@ -208,6 +208,11 @@ async def clan_support(bot: HoshinoBot, ev: CQEvent, token: Tuple[str, str]):
 @pre_process
 async def find_xinsui(bot: HoshinoBot, ev: CQEvent, token: Tuple[str, str]):
     await consumer(FindXinsui(token, bot, ev))
+
+@sv.on_prefix(f"{prefix}jjc回刺")
+@pre_process
+async def jjc_back(bot: HoshinoBot, ev: CQEvent, token: Tuple[str, str]):
+    await consumer(JJCBack(token, bot, ev))
 
 @sv.on_prefix(f"{prefix}查记忆碎片")
 @pre_process

--- a/server.py
+++ b/server.py
@@ -194,6 +194,11 @@ async def clear_daily_all(bot: HoshinoBot, ev: CQEvent, tokens: List[Tuple[str, 
     for token in tokens:
         loop.create_task(consumer(DailyClean(token, bot, ev)))
 
+@sv.on_fullmatch(f"{prefix}卡池")
+async def gacha_current(bot: HoshinoBot, ev: CQEvent):
+    msg = '\n'.join(db.get_cur_gacha())
+    await bot.finish(ev, msg)
+
 @sv.on_prefix(f"{prefix}查心碎")
 @pre_process
 async def find_xinsui(bot: HoshinoBot, ev: CQEvent, token: Tuple[str, str]):

--- a/server.py
+++ b/server.py
@@ -18,7 +18,7 @@ from hoshino.config import SUPERUSERS
 from hoshino.util import escape
 from hoshino.typing import CQEvent, MessageSegment
 from ._util import get_result
-from ._task import DailyClean, FindEquip, FindMemory, FindXinsui, Task, GetLibraryImport, QuestRecommand, Gacha
+from ._task import DailyClean, FindEquip, FindMemory, FindXinsui, Task, GetLibraryImport, QuestRecommand, Gacha, ClanBattleSupport
 import datetime
 import random
 
@@ -198,6 +198,11 @@ async def clear_daily_all(bot: HoshinoBot, ev: CQEvent, tokens: List[Tuple[str, 
 async def gacha_current(bot: HoshinoBot, ev: CQEvent):
     msg = '\n'.join(db.get_cur_gacha())
     await bot.finish(ev, msg)
+
+@sv.on_prefix(f"{prefix}公会支援")
+@pre_process
+async def clan_support(bot: HoshinoBot, ev: CQEvent, token: Tuple[str, str]):
+    await consumer(ClanBattleSupport(token, bot, ev))
 
 @sv.on_prefix(f"{prefix}查心碎")
 @pre_process

--- a/server.py
+++ b/server.py
@@ -225,7 +225,11 @@ async def shilian(bot: HoshinoBot, ev: CQEvent, token: Tuple[str, str]):
     except:
         pass
     try:
-        pool_id = ev.message.extract_plain_text().split(' ')[-2].strip()
+        msg = ev.message.extract_plain_text().split(' ')
+        if cc_until_get:
+            pool_id = msg[-3].strip() + " " + msg[-2].strip()
+        else:
+            pool_id = msg[-2].strip() + " " + msg[-1].strip()
     except:
         pass
 

--- a/server.py
+++ b/server.py
@@ -316,7 +316,7 @@ async def get_config(bot, ev, tot = False):
         user_id = str(ev.user_id)
     else:   #指定对象
         if not priv.check_priv(ev,priv.ADMIN):
-            return False, '[CQ:reply,id={ev.message_id}]指定用户清日常需要管理员权限', token
+            return False, f'[CQ:reply,id={ev.message_id}]指定用户清日常需要管理员权限', token
 
     accounts = []
     alian = escape(alian)
@@ -327,7 +327,7 @@ async def get_config(bot, ev, tot = False):
                 accounts.append((escape(account.alian), file))
 
     if not accounts:
-        return False, "[CQ:reply,id={ev.message_id}]请发送【#配置日常】配置", token
+        return False, f"[CQ:reply,id={ev.message_id}]请发送【{prefix}配置日常】配置", token
 
     if tot:
         return True, "", accounts


### PR DESCRIPTION
- 新增【完成每日jjc/pjjc任务】功能，仅进攻，不结算
- 新增【装备请求】功能
- 新增【会战支援信息】功能
- 新增【jjc回刺阵容查询】功能，并设置一个进攻阵容，仅支持插件端
- 新增【完成每日装备强化/技能升级】功能，仅支持使用辉光球角色
- 修复小屋回赞在特殊情况下数组越界的问题
- 修复记忆碎片计算偏少的问题
- 修复插件端部分消息回复的问题
- 修复限定商店购买时物品超出持有上限的问题
- 修复`is_risk`问题
- 修复查询结果覆盖清日常结果的问题