### PR TITLE
Gacha

### DIFF
--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -716,4 +716,10 @@ class database():
     def chara_love2lovel_level(self, chara_love: int):
         return min([0] + [love[0] for love in self.love_char.values() if love[1] <= chara_love])
 
+    def is_gacha_today_end(self, gacha_id: int) -> bool:
+        gacha_data = self.gacha_data[gacha_id]
+        end_time = self.parse_time(gacha_data.end_time)
+        now = datetime.datetime.now()
+        return now > self.get_start_time(end_time)
+
 db = database()

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -713,8 +713,8 @@ class database():
     def is_stamina_type(self, type_id: int) -> bool:
         return type_id in [eInventoryType.Stamina, eInventoryType.SeasonPassStamina]
 
-    def chara_love2lovel_level(self, chara_love: int):
-        return min([0] + [love[0] for love in self.love_char.values() if love[1] <= chara_love])
+    def chara_love2love_level(self, chara_love: int):
+        return max([0] + [love[0] for love in self.love_char.values() if love[1] <= chara_love])
 
     def is_gacha_today_end(self, gacha_id: int) -> bool:
         gacha_data = self.gacha_data[gacha_id]

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -155,7 +155,7 @@ class RoomMultiGiveGiftResponse(responses.RoomMultiGiveGiftResponse):
 
         if self.level_info:
             for info in self.level_info.love:
-                mgr.unit_love_data[info.chara_id].love_level = db.chara_love2lovel_level(info.total)
+                mgr.unit_love_data[info.chara_id].love_level = db.chara_love2love_level(info.total)
                 mgr.unit_love_data[info.chara_id].chara_love = info.total
 
 

--- a/autopcr/module/modules/gacha.py
+++ b/autopcr/module/modules/gacha.py
@@ -31,6 +31,7 @@ class normal_gacha(Module):
 
 @description('有免费十连时自动抽取')
 @name('免费十连')
+@booltype('today_end_gacha_no_do', "当日切卡池前不抽取", True)
 @default(False)
 class free_gacha(Module):
     async def do_task(self, client: pcrclient):
@@ -55,6 +56,10 @@ class free_gacha(Module):
                 break
         else:
             raise ValueError("target gacha not found")
+
+        switch_no_do = self.get_config("today_end_gacha_no_do")
+        if switch_no_do and db.is_gacha_today_end(target_gacha.id):
+            raise SkipError(f"当前卡池【{db.gacha_data[target_gacha.id].pick_up_chara_text}】于今日结束，不自动抽取\n请自行决定是否抽取")
 
         gacha_reward: GachaReward = GachaReward()
 

--- a/autopcr/module/modules/room.py
+++ b/autopcr/module/modules/room.py
@@ -33,14 +33,23 @@ class room_upper_all(Module):
             cnt += 1
             for item in layout.floor:
                 floors[item.serial_id] = cnt
+        
+        is_warning = False
 
         for x in room.user_room_item_list:
             if db.is_room_item_level_upable(client.data.team_level, x):
-                await client.room_level_up_item(floors[x.serial_id], x)
-                self._log(f"开始升级{db.get_room_item_name(x.room_item_id)}至{x.room_item_level + 1}级")
+                if x.serial_id not in floors:
+                    self._log(f"{db.get_room_item_name(x.room_item_id)}未放置，无法升级")
+                    is_warning = True
+                else:
+                    await client.room_level_up_item(floors[x.serial_id], x)
+                    self._log(f"开始升级{db.get_room_item_name(x.room_item_id)}至{x.room_item_level + 1}级")
 
         if not self.log:
             raise SkipError('没有可升级的家园物品。')
+
+        if is_warning: # 感觉还是把等级放到日志里更好点
+            raise AbortError()
 
 @description('先回赞，再随机点赞')
 @name('公会小屋点赞')

--- a/autopcr/util/arena.py
+++ b/autopcr/util/arena.py
@@ -129,7 +129,9 @@ class ArenaQuery:
                 if res.code:
                     raise ValueError(f'服务器报错：返回值{res.code}')
                 return res.data.result if res.data else []
-            except aiorequests.requests.Timeout as e:
+            except aiorequests.requests.ConnectionError as e:
+                return []
+            except aiorequests.requests.ReadTimeout as e:
                 return []
             except Exception as e:
                 raise e


### PR DESCRIPTION
- 【免费十连】新增【当日切卡池前不抽取】选项
- 修复可升级家具收入仓库时的错误
- 优化arena模块对请求超时的处理
- 修复更新角色好感数据时的逻辑和拼写错误