### PR TITLE
Support smart buyer

### DIFF
--- a/autopcr/module/modules/shop.py
+++ b/autopcr/module/modules/shop.py
@@ -139,15 +139,15 @@ class limit_shop(shop_buyer):
 @singlechoice('underground_shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
 @singlechoice('underground_shop_buy_coin_limit', "货币停止阈值", 10000, [0, 10000, 50000, 100000, 200000])
 @singlechoice("underground_shop_buy_equip_consider_unit", "按角色需求购买装备", "all", ["all", "max_rank", "max_rank-1", "max_rank-2", 'favorite'])
-@inttype('underground_shop_reset_count', "重置次数(<=20)", 0, [i for i in range(21)])
+@inttype('underground_shop_reset_count', "重置次数(<=200)", 0, [i for i in range(201)])
 @multichoice("underground_shop_buy_kind", "购买种类", ['记忆碎片', '装备'], ['记忆碎片', '装备'])
 @name('地下城商店购买')
 @default(False)
 class underground_shop(shop_buyer):
-    def _equip_upper_count(self, client: pcrclient):
-        return self._get_count(client, '装备', 'underground_shop_buy_memory_count_limit')
+    def _equip_count(self, client: pcrclient):
+        return self._get_count(client, '装备', 'underground_shop_buy_equip_count_limit')
     def _unit_memory_count(self, client: pcrclient):
-        return self._get_count(client, '记忆碎片', 'underground_shop_buy_equip_count_limit')
+        return self._get_count(client, '记忆碎片', 'underground_shop_buy_memory_count_limit')
     def coin_limit(self) -> int: return self.get_config('underground_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.EXPEDITION_SHOP
     def reset_count(self) -> int: return self.get_config('underground_shop_reset_count')
@@ -163,10 +163,10 @@ class underground_shop(shop_buyer):
 @name('jjc商店购买')
 @default(False)
 class jjc_shop(shop_buyer):
-    def _equip_upper_count(self, client: pcrclient):
-        return self._get_count(client, '装备', 'jjc_shop_buy_memory_count_limit')
+    def _equip_count(self, client: pcrclient):
+        return self._get_count(client, '装备', 'jjc_shop_buy_equip_count_limit')
     def _unit_memory_count(self, client: pcrclient):
-        return self._get_count(client, '记忆碎片', 'jjc_shop_buy_equip_count_limit')
+        return self._get_count(client, '记忆碎片', 'jjc_shop_buy_memory_count_limit')
     def coin_limit(self) -> int: return self.get_config('jjc_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.ARENA_SHOP
     def reset_count(self) -> int: return self.get_config('jjc_shop_reset_count')
@@ -182,10 +182,10 @@ class jjc_shop(shop_buyer):
 @name('pjjc商店购买')
 @default(False)
 class pjjc_shop(shop_buyer):
-    def _equip_upper_count(self, client: pcrclient):
-        return self._get_count(client, '装备', 'pjjc_shop_buy_memory_count_limit')
+    def _equip_count(self, client: pcrclient):
+        return self._get_count(client, '装备', 'pjjc_shop_buy_equip_count_limit')
     def _unit_memory_count(self, client: pcrclient):
-        return self._get_count(client, '记忆碎片', 'pjjc_shop_buy_equip_count_limit')
+        return self._get_count(client, '记忆碎片', 'pjjc_shop_buy_memory_count_limit')
     def coin_limit(self) -> int: return self.get_config('pjjc_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.GRAND_ARENA_SHOP
     def reset_count(self) -> int: return self.get_config('pjjc_shop_reset_count')

--- a/autopcr/module/modules/shop.py
+++ b/autopcr/module/modules/shop.py
@@ -29,8 +29,9 @@ class shop_buyer(Module):
     def reset_count(self) -> int: ...
     @abstractmethod
     def buy_kind(self) -> List[str]: ...
-    @abstractmethod
-    def require_equip_units(self) -> str: ...
+
+    def require_equip_units(self) -> str:
+        return 'all'
 
     async def _get_shop(self, client: pcrclient):
         res = await client.get_shop_item_list()

--- a/autopcr/module/modules/shop.py
+++ b/autopcr/module/modules/shop.py
@@ -30,8 +30,7 @@ class shop_buyer(Module):
     @abstractmethod
     def buy_kind(self) -> List[str]: ...
     @abstractmethod
-    def require_equip_units(self) -> str:
-        return 'none'
+    def require_equip_units(self) -> str: ...
 
     async def _get_shop(self, client: pcrclient):
         res = await client.get_shop_item_list()
@@ -51,18 +50,16 @@ class shop_buyer(Module):
         result = []
 
         while True:
-            if self.require_equip_units() != 'all':
-                if self.require_equip_units() == 'favorite':
-                    equip_demand_gap = client.data.get_equip_demand_gap(like_unit_only=True)
-                else:
-                    opt: Dict[Union[int, str], int] = {
-                        'max_rank': db.equip_max_rank,
-                        'max_rank-1': db.equip_max_rank - 1,
-                        'max_rank-2': db.equip_max_rank - 2,
-                    }
-                    equip_demand_gap = client.data.get_equip_demand_gap(start_rank=opt[self.require_equip_units()])
+            if self.require_equip_units() == 'favorite':
+                equip_demand_gap = client.data.get_equip_demand_gap(like_unit_only=True)
             else:
-                equip_demand_gap = client.data.get_equip_demand_gap()
+                opt: Dict[Union[int, str], int] = {
+                    'all': 1,
+                    'max_rank': db.equip_max_rank,
+                    'max_rank-1': db.equip_max_rank - 1,
+                    'max_rank-2': db.equip_max_rank - 2,
+                }
+                equip_demand_gap = client.data.get_equip_demand_gap(start_rank=opt[self.require_equip_units()])
 
             memory_demand_gap = client.data.get_memory_demand_gap()
 

--- a/autopcr/module/modules/shop.py
+++ b/autopcr/module/modules/shop.py
@@ -29,6 +29,9 @@ class shop_buyer(Module):
     def reset_count(self) -> int: ...
     @abstractmethod
     def buy_kind(self) -> List[str]: ...
+    @abstractmethod
+    def require_equip_units(self) -> str:
+        return 'none'
 
     async def _get_shop(self, client: pcrclient):
         res = await client.get_shop_item_list()
@@ -48,8 +51,19 @@ class shop_buyer(Module):
         result = []
 
         while True:
-            
-            equip_demand_gap = client.data.get_equip_demand_gap()
+            if self.require_equip_units() != 'all':
+                if self.require_equip_units() == 'favorite':
+                    equip_demand_gap = client.data.get_equip_demand_gap(like_unit_only=True)
+                else:
+                    opt: Dict[Union[int, str], int] = {
+                        'max_rank': db.equip_max_rank,
+                        'max_rank-1': db.equip_max_rank - 1,
+                        'max_rank-2': db.equip_max_rank - 2,
+                    }
+                    equip_demand_gap = client.data.get_equip_demand_gap(start_rank=opt[self.require_equip_units()])
+            else:
+                equip_demand_gap = client.data.get_equip_demand_gap()
+
             memory_demand_gap = client.data.get_memory_demand_gap()
 
             gold = client.data.get_shop_gold(shop_content.system_id)
@@ -59,10 +73,10 @@ class shop_buyer(Module):
             target = [
                 (item.slot_id, item.price.currency_num) for item in shop_content.item_list if not item.sold and
                     (
-                        db.is_exp_upper((item.type, item.item_id)) and client.data.get_inventory((item.type, item.item_id)) < self._exp_count(client) or
-                        db.is_equip_upper((item.type, item.item_id)) and client.data.get_inventory((item.type, item.item_id)) < self._equip_upper_count(client) or
-                        db.is_equip((item.type, item.item_id)) and -equip_demand_gap[(item.type, item.item_id)] < self._equip_count(client) or
-                        db.is_unit_memory((item.type, item.item_id)) and -memory_demand_gap[(item.type, item.item_id)] < self._unit_memory_count(client)
+                        (db.is_exp_upper((item.type, item.item_id)) and client.data.get_inventory((item.type, item.item_id)) < self._exp_count(client)) or
+                        (db.is_equip_upper((item.type, item.item_id)) and client.data.get_inventory((item.type, item.item_id)) < self._equip_upper_count(client)) or
+                        (db.is_equip((item.type, item.item_id)) and -equip_demand_gap[(item.type, item.item_id)] < self._equip_count(client)) or
+                        (db.is_unit_memory((item.type, item.item_id)) and -memory_demand_gap[(item.type, item.item_id)] < self._unit_memory_count(client))
                     )
             ]
 
@@ -121,42 +135,59 @@ class limit_shop(shop_buyer):
     def reset_count(self) -> int: return 0
     def buy_kind(self) -> List[str]: return self.get_config('limit_shop_buy_kind')
 
-@singlechoice('shop_buy_memory_count_limit', "记忆碎片盈余停止阈值", 0, [0, 10, 20, 120, 270, 9900])
-@singlechoice('shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
+@singlechoice('underground_shop_buy_memory_count_limit', "记忆碎片盈余停止阈值", 0, [0, 10, 20, 120, 270, 9900])
+@singlechoice('underground_shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
 @singlechoice('underground_shop_buy_coin_limit', "货币停止阈值", 10000, [0, 10000, 50000, 100000, 200000])
+@singlechoice("underground_shop_buy_equip_consider_unit", "按角色需求购买装备", "all", ["all", "max_rank", "max_rank-1", "max_rank-2", 'favorite'])
 @inttype('underground_shop_reset_count', "重置次数(<=20)", 0, [i for i in range(21)])
 @multichoice("underground_shop_buy_kind", "购买种类", ['记忆碎片', '装备'], ['记忆碎片', '装备'])
 @name('地下城商店购买')
 @default(False)
 class underground_shop(shop_buyer):
+    def _equip_upper_count(self, client: pcrclient):
+        return self._get_count(client, '装备', 'underground_shop_buy_memory_count_limit')
+    def _unit_memory_count(self, client: pcrclient):
+        return self._get_count(client, '记忆碎片', 'underground_shop_buy_equip_count_limit')
     def coin_limit(self) -> int: return self.get_config('underground_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.EXPEDITION_SHOP
     def reset_count(self) -> int: return self.get_config('underground_shop_reset_count')
     def buy_kind(self) -> List[str]: return self.get_config('underground_shop_buy_kind')
+    def require_equip_units(self) -> str: return self.get_config('underground_shop_buy_equip_consider_unit')
 
-@singlechoice('shop_buy_memory_count_limit', "记忆碎片盈余停止阈值", 0, [0, 10, 20, 120, 270, 9900])
-@singlechoice('shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
+@singlechoice('jjc_shop_buy_memory_count_limit', "记忆碎片盈余停止阈值", 0, [0, 10, 20, 120, 270, 9900])
+@singlechoice('jjc_shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
 @singlechoice('jjc_shop_buy_coin_limit', "货币停止阈值", 10000, [0, 10000, 50000, 100000, 200000])
+@singlechoice("jjc_shop_buy_equip_consider_unit", "按角色需求购买装备", "all", ["all", "max_rank", "max_rank-1", "max_rank-2", 'favorite'])
 @inttype('jjc_shop_reset_count', "重置次数(<=20)", 0, [i for i in range(21)])
 @multichoice("jjc_shop_buy_kind", "购买种类", ['记忆碎片', '装备'], ['记忆碎片', '装备'])
 @name('jjc商店购买')
 @default(False)
 class jjc_shop(shop_buyer):
+    def _equip_upper_count(self, client: pcrclient):
+        return self._get_count(client, '装备', 'jjc_shop_buy_memory_count_limit')
+    def _unit_memory_count(self, client: pcrclient):
+        return self._get_count(client, '记忆碎片', 'jjc_shop_buy_equip_count_limit')
     def coin_limit(self) -> int: return self.get_config('jjc_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.ARENA_SHOP
     def reset_count(self) -> int: return self.get_config('jjc_shop_reset_count')
     def buy_kind(self) -> List[str]: return self.get_config('jjc_shop_buy_kind')
+    def require_equip_units(self) -> str: return self.get_config('jjc_shop_buy_equip_consider_unit')
 
-@singlechoice('shop_buy_memory_count_limit', "记忆碎片盈余停止阈值", 0, [0, 10, 20, 120, 270, 9900])
-@singlechoice('shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
+@singlechoice('pjjc_shop_buy_memory_count_limit', "记忆碎片盈余停止阈值", 0, [0, 10, 20, 120, 270, 9900])
+@singlechoice('pjjc_shop_buy_equip_count_limit', "装备盈余停止阈值", 0, [0, 20, 50, 100, 200, 500, 9900])
 @singlechoice('pjjc_shop_buy_coin_limit', "货币停止阈值", 10000, [0, 10000, 50000, 100000, 200000])
+@singlechoice("pjjc_shop_buy_equip_consider_unit", "按角色需求购买装备", "all", ["all", "max_rank", "max_rank-1", "max_rank-2", 'favorite'])
 @inttype('pjjc_shop_reset_count', "重置次数(<=20)", 0, [i for i in range(21)])
 @multichoice("pjjc_shop_buy_kind", "购买种类", ['记忆碎片', '装备'], ['记忆碎片', '装备'])
 @name('pjjc商店购买')
 @default(False)
 class pjjc_shop(shop_buyer):
+    def _equip_upper_count(self, client: pcrclient):
+        return self._get_count(client, '装备', 'pjjc_shop_buy_memory_count_limit')
+    def _unit_memory_count(self, client: pcrclient):
+        return self._get_count(client, '记忆碎片', 'pjjc_shop_buy_equip_count_limit')
     def coin_limit(self) -> int: return self.get_config('pjjc_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.GRAND_ARENA_SHOP
     def reset_count(self) -> int: return self.get_config('pjjc_shop_reset_count')
     def buy_kind(self) -> List[str]: return self.get_config('pjjc_shop_buy_kind')
-
+    def require_equip_units(self) -> str: return self.get_config('pjjc_shop_buy_equip_consider_unit')


### PR DESCRIPTION
支持根据装备库存和需求差来购买几个商店（不包括大师币）的装备；
区分几个商店购买相关数量限制，不再共通；
调整地下城商店重置次数上限到200