### PR TITLE
fea: update unique equip 2 demand & seperate shiori sweep from hard sweep

### DIFF
--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -140,15 +140,19 @@ class database():
                 )
             )
 
-            self.memory_quest: Dict[ItemType, List[QuestDatum]] = (
+            self.memory_hard_quest: Dict[ItemType, List[QuestDatum]] = (
                 QuestDatum.query(db)
                 .where(lambda x: self.is_hard_quest(x.quest_id))
                 .group_by(lambda x: x.reward_image_1)
-                .concat(
-                    ShioriQuest.query(db)
-                    .where(lambda x: self.is_shiori_hard_quest(x.quest_id))
-                    .group_by(lambda x: x.drop_reward_id)
+                .to_dict(lambda x: (eInventoryType.Item, x.key), lambda x:
+                         x.to_list()[::-1]
                 )
+            )
+
+            self.memory_shiori_quest: Dict[ItemType, List[ShioriQuest]] = (
+                ShioriQuest.query(db)
+                .where(lambda x: self.is_shiori_hard_quest(x.quest_id))
+                .group_by(lambda x: x.drop_reward_id)
                 .to_dict(lambda x: (eInventoryType.Item, x.key), lambda x:
                          x.to_list()[::-1]
                 )

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -46,6 +46,7 @@ daily_modules = [
     smart_sweep,
     mirai_very_hard_sweep,
     smart_hard_sweep,
+    smart_shiori_sweep,
     smart_normal_sweep,
 
     all_in_hatsune,

--- a/autopcr/module/modules/tools.py
+++ b/autopcr/module/modules/tools.py
@@ -223,6 +223,11 @@ class Arena(Module):
 
         self._log(f"{self_rank} -> {target_rank}({target_info.user_name})")
 
+        if isinstance(defend[0], list):
+            defend = [d[-5:] for d in defend]
+        else:
+            defend = defend[-5:]
+
         return defend
 
 
@@ -454,7 +459,7 @@ class get_need_memory(Module):
         demand = list(client.data.get_memory_demand_gap().items())
         demand = sorted(demand, key=lambda x: x[1], reverse=True)
         if self.get_config("sweep_get_able_unit_memory"):
-            demand = [i for i in demand if i[0] in db.memory_quest]
+            demand = [i for i in demand if i[0] in db.memory_hard_quest or i[0] in db.memory_shiori_quest]
 
         msg = '\n'.join([f'{db.get_inventory_name_san(item[0])}: {"缺少" if item[1] > 0 else "盈余"}{abs(item[1])}片' for item in demand])
         self._log(msg)


### PR DESCRIPTION
- 【专二纯净碎片储备】新增生菜和七七香的刷取需求
- 调整【智能刷hard图】功能，不再刷取外传本。
- 新增【智能刷外传图】功能，根据记忆碎片缺口刷外传图。