### PR TITLE
Fix

### DIFF
--- a/autopcr/module/modules/autosweep.py
+++ b/autopcr/module/modules/autosweep.py
@@ -236,6 +236,9 @@ unique_equip_2_pure_memory_id = [
         (32013, 1), # 七七香
         (32028, 1), # 水电
         (32018, 1), # 老师
+        (32043, 1), # 水狼
+        (32017, 1), # 水狗
+        (32010, 1), # 水狐
 ]
 @conditional_execution("very_hard_sweep_run_time", ["vh庆典"])
 @description('储备专二需求的150碎片，包括' + ','.join(db.get_item_name(item_id) for item_id, _ in unique_equip_2_pure_memory_id))

--- a/autopcr/module/modules/shop.py
+++ b/autopcr/module/modules/shop.py
@@ -106,8 +106,8 @@ class shop_buyer(Module):
             msg = await client.serlize_reward(result)
             self._log(msg)
 
-@singlechoice('shop_buy_exp_count_limit', "经验药水储备", 99000, [100, 1000, 5000, 10000, 50000, 99000])
-@singlechoice('shop_buy_equip_upper_count_limit', "强化石储备", 99000, [100, 1000, 5000, 10000, 50000, 99000])
+@singlechoice('shop_buy_exp_count_limit', "经验药水储备", 999000, [1000, 10000, 100000, 500000, 999000])
+@singlechoice('shop_buy_equip_upper_count_limit', "强化石储备", 999000, [1000, 10000, 100000, 500000, 999000])
 @singlechoice('normal_shop_buy_coin_limit', "货币阈值", 5000000, [0, 5000000, 10000000, 20000000])
 @inttype('normal_shop_reset_count', "重置次数(<=20)", 0, [i for i in range(21)])
 @multichoice("normal_shop_buy_kind", "购买种类", ['经验药水', '强化石'], ['经验药水', '强化石'])
@@ -126,8 +126,8 @@ class normal_shop(shop_buyer):
 @name('限定商店购买')
 @default(False)
 class limit_shop(shop_buyer):
-    def _exp_count(self): return 99000 if "经验药水" in self.get_config('limit_shop_buy_kind') else 0
-    def _equip_count(self): return 9900 if "装备" in self.get_config('limit_shop_buy_kind') else 0
+    def _exp_count(self): return 999000 if "经验药水" in self.get_config('limit_shop_buy_kind') else 0
+    def _equip_count(self): return 999000 if "装备" in self.get_config('limit_shop_buy_kind') else 0
     def coin_limit(self) -> int: return self.get_config('limit_shop_buy_coin_limit')
     def system_id(self) -> eSystemId: return eSystemId.LIMITED_SHOP
     def reset_count(self) -> int: return 0

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -247,9 +247,10 @@ class unit_skill_level_up(UnitController):
 
             for pos, skill in skills:
                 try:
-                    await self.unit_skill_up_aware(pos, skill, skill().skill_level + 1, growth_limit)
-                    stop = True
-                    break
+                    if skill().skill_level < self.unit.unit_level:
+                        await self.unit_skill_up_aware(pos, skill, skill().skill_level + 1, growth_limit)
+                        stop = True
+                        break
                 except AbortError as e:
                     print(e)
                     continue

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -241,9 +241,9 @@ class unit_skill_level_up(UnitController):
         stop = False
 
         while not stop:
-            skills = [(eSkillLocationCategory(eSkillLocationCategory.UNION_BURST_SKILL + id), lambda: self.unit.union_burst[id]) for id, skill in enumerate(self.unit.union_burst)] +  \
-                    [(eSkillLocationCategory(eSkillLocationCategory.MAIN_SKILL_1 + id), lambda: self.unit.main_skill[id]) for id, skill in enumerate(self.unit.main_skill)] +  \
-                    [(eSkillLocationCategory(eSkillLocationCategory.EX_SKILL_1 + id), lambda: self.unit.ex_skill[id]) for id, skill in enumerate(self.unit.ex_skill)]
+            skills = [(eSkillLocationCategory(eSkillLocationCategory.UNION_BURST_SKILL + id), lambda id=id: self.unit.union_burst[id]) for id, skill in enumerate(self.unit.union_burst)] +  \
+                    [(eSkillLocationCategory(eSkillLocationCategory.MAIN_SKILL_1 + id), lambda id=id: self.unit.main_skill[id]) for id, skill in enumerate(self.unit.main_skill)] +  \
+                    [(eSkillLocationCategory(eSkillLocationCategory.EX_SKILL_1 + id), lambda id=id: self.unit.ex_skill[id]) for id, skill in enumerate(self.unit.ex_skill)]
 
             for pos, skill in skills:
                 try:

--- a/autopcr/util/draw_table.py
+++ b/autopcr/util/draw_table.py
@@ -4,10 +4,12 @@ from io import BytesIO
 import base64
 
 def outp_b64(outp_img):
-        buf = BytesIO()
-        outp_img.save(buf, format='JPEG')
-        base64_str = f'base64://{base64.b64encode(buf.getvalue()).decode()}'
-        return f'[CQ:image,file={base64_str}]'
+    if isinstance(outp_img, str):
+        outp_img = Image.open(outp_img)
+    buf = BytesIO()
+    outp_img.save(buf, format='JPEG')
+    base64_str = f'base64://{base64.b64encode(buf.getvalue()).decode()}'
+    return f'[CQ:image,file={base64_str}]'
 
 def position_tuple(*args):
     Position = namedtuple('Position', ['top', 'right', 'bottom', 'left'])

--- a/server.py
+++ b/server.py
@@ -43,7 +43,7 @@ sv_help = f"""
 - {prefix}日常报告 [0|1|2|3] 最近四次清日常报告
 - {prefix}定时日志 查看定时运行状态
 - {prefix}查心碎 查询缺口心碎
-- {prefix}查记忆碎片 [可刷取] 查询缺口记忆碎片，可刷取只仅查看h图可刷的碎片
+- {prefix}查记忆碎片 [可刷取|大师币] 查询缺口记忆碎片，可按地图可刷取或大师币商店过滤
 - {prefix}查装备 [<rank>] [fav] 查询缺口装备，rank为数字，只查询>=rank的角色缺口装备，fav表示只查询favorite的角色
 - {prefix}刷图推荐 [<rank>] [fav] 查询缺口装备的刷图推荐，格式同上
 - {prefix}公会支援 查询公会支援角色配置
@@ -535,14 +535,17 @@ async def pjjc_info(botev: BotEvent):
 
 @register_tool("查记忆碎片", "get_need_memory")
 async def find_memory(botev: BotEvent):
-    sweep_get_able_unit_memory = False
+    memory_demand_consider_unit = '所有'
     msg = await botev.message()
     try:
-        sweep_get_able_unit_memory = is_args_exist(msg, '可刷取')
+        if is_args_exist(msg, '可刷取'):
+            memory_demand_consider_unit = '地图可刷取'
+        elif is_args_exist(msg, '大师币'):
+            memory_demand_consider_unit = '大师币商店'
     except:
         pass
     config = {
-        "sweep_get_able_unit_memory": sweep_get_able_unit_memory,
+        "memory_demand_consider_unit": memory_demand_consider_unit,
     }
     return config
 

--- a/server.py
+++ b/server.py
@@ -10,12 +10,11 @@ from .autopcr.util.draw import instance as drawer
 import asyncio
 
 import nonebot
-from nonebot import MessageSegment
 from nonebot import on_startup
 import hoshino
 from hoshino import HoshinoBot, Service, priv
 from hoshino.util import escape
-from hoshino.typing import CQEvent, MessageSegment
+from hoshino.typing import CQEvent
 from quart_auth import QuartAuth
 from quart_rate_limiter import RateLimiter
 from quart_compress import Compress
@@ -351,7 +350,7 @@ async def clean_daily_from(botev: BotEvent, acc: Account):
     try:
         img = await clean_daily(botev = botev, acc = acc)
         msg = f"{alias}"
-        msg += MessageSegment.image(f'file:///{img}')
+        msg += outp_b64(img)
         await botev.send(msg)
     except Exception as e:
         await botev.send(f'{alias}: {e}')
@@ -377,7 +376,7 @@ async def clean_daily_result(botev: BotEvent, acc: Account):
     img = await acc.get_daily_result_from_id(result_id)
     if not img:
         await botev.finish("未找到日常报告")
-    await botev.finish(MessageSegment.image(f'file:///{img}'))
+    await botev.finish(outp_b64(img))
 
 @sv.on_prefix(f"{prefix}日常记录")
 @wrap_hoshino_event
@@ -454,7 +453,7 @@ async def tool_used(botev: BotEvent, tool: ToolInfo, config: Dict[str, str], acc
 
         img = await acc.do_from_key(config, tool.key)
         msg = f"{alias}"
-        msg += MessageSegment.image(f'file:///{img}')
+        msg += outp_b64(img)
         await botev.send(msg)
     except Exception as e:
         await botev.send(f'{alias}: {e}')


### PR DESCRIPTION
- 【专二纯净碎片储备】新增狼、狗、狐狸（水狼、水狗、水狐）的纯净碎片刷取需求
- 【查记忆碎片】选项更新，新增查询大师币商店的需求，指令为【#查记忆碎片 大师币】，地图可刷去的为【#查记忆碎片 可刷取】
- 修复某些情况技能升级出错的问题，优化技能升级的顺序
- 更新商店部分物品的持有上限