### PR TITLE
Fix

### DIFF
--- a/autopcr/bsdk/bsdkclient.py
+++ b/autopcr/bsdk/bsdkclient.py
@@ -1,6 +1,6 @@
-
 from .bsgamesdk import login
-from .validator import autoValidator, manualValidator
+from .validator import autoValidator
+from ..model.error import PanicError
 
 async def _defaultLogger(msg):
     print(msg)
@@ -30,6 +30,6 @@ class bsdkclient:
                 await self.errlogger("geetest or captcha succeed")
                 break
             await self.errlogger(resp['message'])
-            raise ValueError(resp['message'])
+            raise PanicError(resp['message'])
 
         return resp['uid'], resp['access_key']

--- a/autopcr/bsdk/validator.py
+++ b/autopcr/bsdk/validator.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from ..util import aiorequests, questutils
+from ..model.error import PanicError
 from json import loads
 import asyncio
 from dataclasses import dataclass
@@ -42,7 +43,7 @@ async def manualValidator(account, gt, challenge, userid):
             del validate_ok_dict[id]
             break
     else:
-        raise ValueError("验证码验证超时")
+        raise PanicError("验证码验证超时")
 
     return info
 

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -19,6 +19,7 @@ from asyncio import Lock
 class datamgr(Component[apiclient]):
     settings: IniSetting = None
     dungeon_avaliable: bool = False
+    resident_info: MonthlyGachaInfo = None
     finishedQuest: Set[int] = None
     jewel: UserJewel = None
     gold: UserGold = None

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -106,6 +106,11 @@ class datamgr(Component[apiclient]):
             "h3及以上": lambda: self.get_hard_quest_campaign_times() >= 3,
             "vh2": lambda: self.get_very_hard_quest_campaign_times() == 2,
             "vh3及以上": lambda: self.get_very_hard_quest_campaign_times() >= 3,
+            "无庆典": lambda: not self.is_quest_campaign(),
+            "n庆典": lambda: self.is_normal_quest_campaign(),
+            "h庆典": lambda: self.is_hard_quest_campaign(),
+            "vh庆典": lambda: self.is_very_hard_quest_campaign(),
+            "总是执行": lambda: True,
         }
         if campaign not in campaign_list:
             raise ValueError(f"不支持的庆典查询：{campaign}")
@@ -405,16 +410,18 @@ class datamgr(Component[apiclient]):
             return self.gold.gold_id_free + self.gold.gold_id_pay
         if shop_id == eSystemId.LIMITED_SHOP: # 限定商店
             return self.gold.gold_id_free + self.gold.gold_id_pay
+        elif shop_id == eSystemId.EXPEDITION_SHOP: # 地下城店
+            return self.get_inventory((eInventoryType.Item, 90002))
         elif shop_id == eSystemId.ARENA_SHOP: # jjc店
             return self.get_inventory((eInventoryType.Item, 90003))
         elif shop_id == eSystemId.GRAND_ARENA_SHOP: # pjjc店
             return self.get_inventory((eInventoryType.Item, 90004))
-        elif shop_id == eSystemId.EXPEDITION_SHOP: # 地下城店
-            return self.get_inventory((eInventoryType.Item, 90002))
-        elif shop_id == eSystemId.CLAN_BATTLE_SHOP: # 会战店
-            return self.get_inventory((eInventoryType.Item, 90006))
         elif shop_id == eSystemId.MEMORY_PIECE_SHOP: # 女神店
             return self.get_inventory((eInventoryType.Item, 90005))
+        elif shop_id == eSystemId.CLAN_BATTLE_SHOP: # 会战店
+            return self.get_inventory((eInventoryType.Item, 90006))
+        elif shop_id == eSystemId.GOLD_SHOP: # 小屋商店
+            return self.get_inventory((eInventoryType.Item, 90007))
         elif shop_id == eSystemId.COUNTER_STOP_SHOP: # 大师店
             return self.get_inventory((eInventoryType.Item, 90008))
         else:

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -21,6 +21,10 @@ class pcrclient(apiclient):
     def name(self) -> str:
         return self.data.name
 
+    @property
+    def logged(self):
+        return self.session._logged
+
     async def login(self):
         await self.request(None)
 
@@ -737,14 +741,10 @@ class pcrclient(apiclient):
 
     @property
     def stamina_recover_cnt(self) -> int:
-        if self.data.is_normal_quest_campaign():
-            times = min(4, self.data.get_normal_quest_campaign_times())
-            return self.keys.get(f'sweep_recover_stamina_times_n{times}', 0)
-        elif self.data.is_hard_quest_campaign():
-            times = min(3, self.data.get_hard_quest_campaign_times())
-            return self.keys.get(f'sweep_recover_stamina_times_h{times}', 0)
-        else:
-            return self.keys.get(f'sweep_recover_stamina_times', 0)
+        return self.keys.get('stamina_recover_times', 0)
+
+    def set_stamina_recover_cnt(self, value: int):
+        self.keys['stamina_recover_times'] = value
 
     async def quest_skip_aware(self, quest: int, times: int, recover: bool = False, is_total: bool = False):
         name = db.quest_name[quest] if quest in db.quest_name else f"未知关卡{quest}"
@@ -990,3 +990,33 @@ class pcrclient(apiclient):
         req.drama_id = drama_id
         req.from_system_id = from_system_id
         return await self.request(req)
+
+    def set_stamina_consume_not_run(self):
+        self.keys['stamina_consume_not_run'] = True
+
+    def is_stamina_consume_not_run(self):
+        return self.keys.get('stamina_consume_not_run', False)
+
+    def set_stamina_get_not_run(self):
+        self.keys['stamina_get_not_run'] = True
+
+    def is_stamina_get_not_run(self):
+        return self.keys.get('stamina_get_not_run', False)
+
+    def set_star_cup_sweep_not_run(self):
+        self.keys['star_cup_sweep_not_run'] = True
+
+    def is_star_cup_sweep_not_run(self):
+        return self.keys.get('star_cup_sweep_not_run', False)
+
+    def set_heart_sweep_not_run(self):
+        self.keys['heart_sweep_not_run'] = True
+
+    def is_heart_sweep_not_run(self):
+        return self.keys.get('heart_sweep_not_run', False)
+
+    def set_cron_run(self):
+        self.keys['cron_run'] = True
+
+    def is_cron_run(self):
+        return self.keys.get('cron_run', False)

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -190,6 +190,10 @@ class pcrclient(apiclient):
         req = GachaIndexRequest()
         return await self.request(req)
 
+    async def get_gacha_resident_index(self):
+        req = GachaMonthlyIndexRequest()
+        return await self.request(req)
+
     async def gacha_select_prize(self, prizegacha_id: int, item_id: int):
         req = GachaSelectPrizeRequest()
         req.prizegacha_id = prizegacha_id

--- a/autopcr/core/sessionmgr.py
+++ b/autopcr/core/sessionmgr.py
@@ -69,14 +69,14 @@ class sessionmgr(Component[apiclient]):
                                 if not (await next.request(req)).is_risk:
                                     break
                             else:
-                                raise ValueError("登录失败，帐号存在风险")
+                                raise PanicError("登录失败，帐号存在风险")
                     except ApiException:
                         pass
                 
                 self._sdkaccount = None
                 await self._bililogin()
             else:
-                raise ValueError("登录失败")
+                raise PanicError("登录失败")
         except Exception:
             raise
         finally:
@@ -94,7 +94,7 @@ class sessionmgr(Component[apiclient]):
                 manifest = await next.request(SourceIniGetMaintenanceStatusRequest())
                 self._container._headers['MANIFEST-VER'] = manifest.required_manifest_ver
                 if manifest.maintenance_message:
-                    raise ValueError(manifest.maintenance_message)
+                    raise PanicError(manifest.maintenance_message)
                 
                 await self._ensure_token(next)
                 
@@ -104,7 +104,7 @@ class sessionmgr(Component[apiclient]):
                 req.campaign_user = random.randint(0, 100000) & ~1
                 
                 if not (await next.request(req)).now_tutorial:
-                    raise ValueError("账号未过完教程")
+                    raise PanicError("账号未过完教程")
                 
                 # await next.request(CheckAgreementRequest())
 

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -700,20 +700,6 @@ class database():
     def get_campaign_times(self, campaign_id: int) -> float:
         return self.campaign_schedule[campaign_id].value
 
-    def get_dungeon_mana_before_day(self) -> int:
-        now = datetime.datetime.now()
-        dungeon = (
-            flow(self.campaign_schedule.values())
-            .where(
-                lambda x: x.campaign_category == eCampaignCategory.GOLD_DROP_AMOUNT_DUNGEON and 
-                db.parse_time(x.start_time) > now
-            )
-            .min(lambda x: x.start_time)
-        )
-        today = self.get_today_start_time()
-        dungeon = self.get_start_time(db.parse_time(dungeon[2]))
-        return (dungeon - today).days
-
     def get_active_hatsune(self) -> List[HatsuneSchedule]:
         now = datetime.datetime.now()
         return flow(self.hatsune_schedule.values()) \

--- a/autopcr/model/common.py
+++ b/autopcr/model/common.py
@@ -2,11 +2,6 @@ from typing import List, Dict
 from .enums import *
 from pydantic import BaseModel, Field
 
-class LegionBattleIniSetting(BaseModel):
-    support_limit: int = None
-    support_change_interval: int = None
-    remaining_count_max: int = None
-    limit_unit_level: int = None
 class SkillLevelInfo(BaseModel):
     skill_id: int = None
     skill_level: int = None
@@ -125,6 +120,8 @@ class UnitData(BaseModel):
     TotalAccuracy: int = None
     TotalEnergyRecoveryRate: int = None
     TotalEnergyReduceRate: int = None
+    UniqueEquipSlot1: EquipSlot = None
+    UniqueEquipSlot2: EquipSlot = None
 class DuplicateUnitInfo(BaseModel):
     unit_id: int = None
     rarity: int = None
@@ -345,6 +342,7 @@ class ClanBattleBattleLog(BaseModel):
     enemy_damage: int = None
     is_auto: int = None
     units: List[MyLogUnitData] = None
+    phase: int = None
 class BossHistory(BaseModel):
     id: int = None
     difficulty: int = None
@@ -530,6 +528,7 @@ class BossInfo(BaseModel):
     enemy_id: int = None
     max_hp: int = None
     current_hp: int = None
+    phase: int = None
 class BossReward(BaseModel):
     clan_battle_id: int = None
     lap_num: int = None
@@ -538,6 +537,7 @@ class BossReward(BaseModel):
     kill_time: int = None
     reward_info: List[InventoryInfo] = None
     period: int = None
+    phase: int = None
 class RankResult(BaseModel):
     clan_battle_id: int = None
     period: int = None
@@ -553,6 +553,7 @@ class ClanBattleCarryOverInfo(BaseModel):
     using_unit: List[int] = None
     support_owner_viewer_id: int = None
     support_unit: UnitDataForView = None
+    change_phase: int = None
 class ClanBattleTopUserClanInformation(BaseModel):
     clan_name: str = None
     clan_role: int = None
@@ -673,6 +674,7 @@ class DailyTaskParam(BaseModel):
     random_clan_member_name: str = None
     remaining_count: int = None
     is_season_changed: bool = None
+    special_dungeon_challenged: bool = None
 class DailyTaskData(BaseModel):
     task_type: int = None
     status: int = None
@@ -939,6 +941,7 @@ class GachaParameter(BaseModel):
     exec_count: int = None
     select_pickup_slot_num: int = None
     priority_list: List[int] = None
+    original_gacha_id: int = None
 class CampaignGachaInfo(BaseModel):
     campaign_id: int = None
     fg1_exec_cnt: int = None
@@ -1547,6 +1550,14 @@ class SpecialFesDiscountIniSetting(BaseModel):
     open_time: int = None
     limit_count: int = None
     cost: int = None
+class CaravanSetting(BaseModel):
+    limit_caravan_mile: int = None
+    limit_caravan_lottery: int = None
+    limit_caravan_treasure: int = None
+    limit_caravan_treasure_by_type: int = None
+    limit_caravan_dish_by_type: int = None
+class MultiRankUnitLimitSetting(BaseModel):
+    multi_rank_unit_limit: int = None
 class IniSetting(BaseModel):
     equipment_enhance: EquipStrSetting = None
     quest: QuestSetting = None
@@ -1577,7 +1588,7 @@ class IniSetting(BaseModel):
     multiple_skip: BulkSkipSetting = None
     friend_support_unit: FriendSupportUnitIniSetting = None
     kaiser_battle: KaiserBattleIniSetting = None
-    legion_battle: LegionBattleIniSetting = None
+    legion_battle: StoryRaidEvenBattletIniSetting = None
     sre: StoryRaidEvenBattletIniSetting = None
     serial_code: SerialCodeIniSetting = None
     arena_skip_upper_rank: int = None
@@ -1586,6 +1597,8 @@ class IniSetting(BaseModel):
     ex_equip: ExEquipIniSetting = None
     max_once_consume_gold: MaxOnceConsumeGoldSetting = None
     sfd: SpecialFesDiscountIniSetting = None
+    caravan: CaravanSetting = None
+    multi_rank_unit_limit: MultiRankUnitLimitSetting = None
 class LoginBonusData(BaseModel):
     campaign_id: int = None
     total_count: int = None
@@ -1886,6 +1899,7 @@ class ProfileQuestInfo(BaseModel):
     normal_quest: List[int] = None
     hard_quest: List[int] = None
     very_hard_quest: List[int] = None
+    byway_quest: int = None
 class SupportUnitForProfile(BaseModel):
     position: int = None
     unit_data: UnitDataLight = None
@@ -2350,6 +2364,7 @@ class TravelAppearTopEvent(BaseModel):
     IsDebugCreate: bool = None
     IsDebugDispTreasure: bool = None
     DebugChoiceSelectDramaId: int = None
+    DebugDispRewardNum: int = None
 class TrialBattleFinishUnit(BaseModel):
     unit_damage_list: List[UnitDamageInfo] = None
     unit_hp_list: List[UnitHpInfo] = None
@@ -2502,6 +2517,139 @@ class VoteRanking(BaseModel):
     rarity_1: List[VoteRank] = None
     rarity_2: List[VoteRank] = None
     rarity_3: List[VoteRank] = None
+class AsmAnswerInfo(BaseModel):
+    wave_no: int = None
+    asm_id: int = None
+    answer: List[int] = None
+    elapsed_msec: int = None
+    is_correct: bool = None
+class AsmScoreResult(BaseModel):
+    correct_count: int = None
+    correct_score: int = None
+    elapsed_msec_avg: int = None
+    elapsed_msec_avg_score: int = None
+    total_score: int = None
+    past_high_score: int = None
+class AsmRewardInfo(BaseModel):
+    trigger_score: int = None
+    reward_type: eInventoryType = None
+    reward_id: int = None
+    reward_count: int = None
+class AsmUnlockStory(BaseModel):
+    trigger_score: int = None
+    story_id: int = None
+class AsmMemoryGaugeEmblem(BaseModel):
+    trigger_score: int = None
+    emblem_id: int = None
+class AsmCompletionEmblem(BaseModel):
+    archive_num: int = None
+    emblem_id: int = None
+class AsmArchiveInfo(BaseModel):
+    asm_id: int = None
+    status: int = None
+class AsmMemoryGaugeInfo(BaseModel):
+    gauge_id: int = None
+    score: int = None
+class BywayDeliveryItemInfo(BaseModel):
+    slot_id: int = None
+    condition_id: int = None
+    consume_num: int = None
+class CaravanDishSellData(BaseModel):
+    id: int = None
+    current_num: int = None
+    sell_num: int = None
+class CaravanDishData(BaseModel):
+    id: int = None
+    stock: int = None
+class CaravanShopBlockLineup(BaseModel):
+    slot_id: int = None
+    type: int = None
+    item_id: int = None
+    num: int = None
+    price: int = None
+    discounted_price: int = None
+    discount_rate: int = None
+    is_sold: int = None
+class CccFinishItemCountInfo(BaseModel):
+    ccc_object_id: int = None
+    count: int = None
+class CaravanGoalBonusTreasureData(BaseModel):
+    id: int = None
+    count: int = None
+class CaravanTreasureAppraisalData(BaseModel):
+    id: int = None
+    result_id: int = None
+class CaravanDishEffectData(BaseModel):
+    id: int = None
+    effect_turn: int = None
+    effect_count: int = None
+class CaravanEventEffectData(BaseModel):
+    event_id: int = None
+    effect_turn: int = None
+    effect_count: int = None
+class CaravanTreasureData(BaseModel):
+    id: int = None
+    stock: int = None
+class CaravanCoinShopData(BaseModel):
+    slot_id: int = None
+    purchase_count: int = None
+class CaravanResetTreasureData(BaseModel):
+    id: int = None
+    count: int = None
+class CaravanTopGoalReward(BaseModel):
+    goal_turn: int = None
+    lottery_result_list: List[InventoryInfo] = None
+    treasure_appraisal_list: List[CaravanTreasureAppraisalData] = None
+    reset_treasure_list: List[CaravanResetTreasureData] = None
+class ColosseumBattleFinishUnitInfo(BaseModel):
+    damage: int = None
+    unit_id: int = None
+    hp: int = None
+    passive_skill_hp: int = None
+class ColosseumScore(BaseModel):
+    quest_id: int = None
+    score: int = None
+    battle_point: int = None
+    win_point: int = None
+    enemy_hp_point: int = None
+    unit_hp_point: int = None
+    team_level: int = None
+    remain_time: int = None
+    remain_time_point: int = None
+    bonus_applied_point_1: int = None
+    bonus_applied_point_2: int = None
+class ColosseumUnitDamageInfo(BaseModel):
+    is_my_unit: int = None
+    unit_id: int = None
+    damage: int = None
+class ColosseumHistoryInfo(BaseModel):
+    replay_log_id: int = None
+    win_or_lose: int = None
+    user_unit_info: List[UnitDataForView] = None
+    versus_user_unit_info: List[UnitDataForView] = None
+    damage_list: List[ColosseumUnitDamageInfo] = None
+    score: ColosseumScore = None
+class ColosseumRankingInfo(BaseModel):
+    rank: int = None
+    team_level: int = None
+    user_name: str = None
+    emblem: EmblemData = None
+    favorite_unit: UnitDataForView = None
+    total_score: int = None
+class MonthlyFreeGachaInfo(BaseModel):
+    fg1_exec_cnt: int = None
+    fg1_last_exec_time: int = None
+    fg10_exec_cnt: int = None
+    fg10_last_exec_time: int = None
+class BeginnerCharaExchangeTicketProductData(BaseModel):
+    csv_data_id: int = None
+    beginner_id: int = None
+    ticket_id: int = None
+    ticket_count: int = None
+    forced_exchange_time: int = None
+    number_of_product_purchased: int = None
+    start_time: int = None
+    end_time: int = None
 class SeasonPassData(BaseModel):
     SeasonPassRewards: Dict[int, List[int]] = None
     HasBuy: bool = None
@@ -2514,9 +2662,38 @@ class SeasonPassData(BaseModel):
     weekly_point: int = None
     missions: List[UserMissionInfo] = None
     received_rewards: List[int] = None
+class BannerLinkedPackList(BaseModel):
+    id: int = None
+    remaining_count: int = None
+    start_time: int = None
+    end_time: int = None
+class MonthlyGachaInfo(BaseModel):
+    end_time: int = None
+    original_gacha_id: int = None
+    exchange_num: int = None
+    max_exchange_num: int = None
+    gacha_point_info: GachaPointInfo = None
 class ExchangeRewards(BaseModel):
     id: int = None
     type: int = None
     count: int = None
     stock: int = None
     received: int = None
+class BuyBulkBuyItemList(BaseModel):
+    slot_id: int = None
+    count: int = None
+class TravelRoundEventResult(BaseModel):
+    Result: eRoundEventResultType = None
+    result_drama_id: int = None
+    reward_list: List[InventoryInfo] = None
+class TravelAppearRoundEvent(BaseModel):
+    round_event_id: int = None
+    skin_id_list: List[int] = None
+    round: int = None
+    left_door_effect_id: int = None
+    right_door_effect_id: int = None
+    expect_reward_list: List[InventoryInfo] = None
+class MultiAutomaticPromotion(BaseModel):
+    unit_id: int = None
+    equip_recipe_list: List[RequiredMaterialList] = None
+    item_list: List[ItemInfo] = None

--- a/autopcr/model/enums.py
+++ b/autopcr/model/enums.py
@@ -20,13 +20,16 @@ class eInventoryType(IntEnum):
     BankGold = 17
     ExtraEquip = 18
     CustomMyPageFrame = 19
-    EquipmentBox = 50
-    SeasonPassStamina = 51
     RoomItemLevelUp = 901
-    SeasonPassPoint = 1001
-    SeasonPassLevel = 1002
     Other = 9999
     INVALID_VALUE = -1
+    CaravanItem = 21
+    CaravanTreasure = 22
+    CaravanDish = 23
+    EquipmentBox = 50
+    SeasonPassStamina = 51
+    SeasonPassPoint = 1001
+    SeasonPassLevel = 1002
 
 class ePromotionLevel(IntEnum):
     LEVEL_1 = 1
@@ -119,6 +122,17 @@ class ePartyType(IntEnum):
     STORY_RAID_EVENT_RAID_4 = 1008
     MIROKU_MAIN_BATTLE = 3008
     INVALID_VALUE = -1
+    BYWAY_QUEST = 42
+    BYWAY_QUEST_EX = 43
+    COLOSSEUM_NORMAL_1 = 44
+    COLOSSEUM_NORMAL_2 = 45
+    COLOSSEUM_NORMAL_3 = 46
+    COLOSSEUM_HARD_1 = 47
+    COLOSSEUM_HARD_2 = 48
+    COLOSSEUM_HARD_3 = 49
+    COLOSSEUM_EXTRA_1 = 50
+    COLOSSEUM_EXTRA_2 = 51
+    COLOSSEUM_EXTRA_3 = 52
 
 class eClanRole(IntEnum):
     MEMBER = 0
@@ -326,6 +340,13 @@ class eSystemId(IntEnum):
     SHIORI_EVENT_COMMON_BOSS = 8008
     SHIORI_EVENT_VERY_HARD_BOSS = 8010
     INVALID_VALUE = -1
+    BYWAY_QUEST = 126
+    COLOSSEUM = 127
+    CARAVAN = 128
+    SEASON_PASS = 90001
+    MONTHLY_GACHA = 90002
+    CARAVAN_MILE_SHOP = 990001
+    CARAVAN_COIN_SHOP = 990002
 
 class eShopItemBannerType(IntEnum):
     NONE = 0
@@ -445,6 +466,8 @@ class eGachaDrawType(IntEnum):
     SpFesCmapaign10Shot = 10
     SpFesDiscount10Shot = 11
     INVALID_VALUE = -1
+    Monthly_Free_Single = 9005
+    Monthly_Free_Multi = 9006
 
 class eSkillLocationCategory(IntEnum):
     NO_SKILLSLOT = 0
@@ -578,3 +601,9 @@ class eStoryVisibleType(IntEnum):
 	DUMMY_STORY_ONLY_ALBUM = 10
 	DUMMY_STORY_NOT_OP_LOGO = 11
 	EVENT_SPECIAL_STORY = 12
+
+class eRoundEventResultType(IntEnum):
+    SUCCESS = 1
+    FAILURE = 2
+    END = 3
+

--- a/autopcr/model/error.py
+++ b/autopcr/model/error.py
@@ -3,3 +3,6 @@ class SkipError(Exception):
 
 class AbortError(Exception):
     pass
+
+class PanicError(Exception): 
+    pass

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -265,6 +265,8 @@ class LoadIndexResponse(responses.LoadIndexResponse):
         mgr.team_level = self.user_info.team_level
         mgr.jewel = self.user_jewel
         mgr.gold = self.user_gold
+        if self.resident_info:
+            mgr.resident_info = self.resident_info
         if self.bank_bought:
             mgr.user_gold_bank_info = self.user_gold_bank_info
         mgr.clan_like_count = self.clan_like_count

--- a/autopcr/model/requests.py
+++ b/autopcr/model/requests.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 from .modelbase import Request
 from .responses import *
 from .common import *
@@ -320,6 +320,7 @@ class ClanBattleFinishRequest(Request[ClanBattleFinishResponse]):
     timeline: List[UnitUnionBurstTimeline] = None
     battle_time: int = None
     start_remain_time: int = None
+    phase: int = None
     battle_log: str = None
     @property
     def url(self) -> str:
@@ -373,6 +374,7 @@ class ClanBattleRehearsalFinishRequest(Request[ClanBattleRehearsalFinishResponse
     start_remain_time: int = None
     is_auto: int = None
     stock_index: int = None
+    phase: int = None
     @property
     def url(self) -> str:
         return "clan_battle/rehearsal_finish"
@@ -387,6 +389,8 @@ class ClanBattleRehearsalStartRequest(Request[ClanBattleRehearsalStartResponse])
     changed_support_battle_rarity: int = None
     is_actual_boss_status: int = None
     stock_index: int = None
+    phase: int = None
+    is_difficulty_change: int = None
     @property
     def url(self) -> str:
         return "clan_battle/rehearsal_start"
@@ -417,6 +421,7 @@ class ClanBattleSaveRehearsalMyLogRequest(Request[ClanBattleSaveRehearsalMyLogRe
     timeline: List[UnitUnionBurstTimeline] = None
     battle_time: int = None
     start_remain_time: int = None
+    phase: int = None
     @property
     def url(self) -> str:
         return "clan_battle/save_rehearsal_mylog"
@@ -453,6 +458,8 @@ class ClanBattleStartRequest(Request[ClanBattleStartResponse]):
     changed_support_battle_rarity: int = None
     remaining_count: int = None
     stock_index: int = None
+    phase: int = None
+    is_difficulty_change: int = None
     @property
     def url(self) -> str:
         return "clan_battle/start"
@@ -462,6 +469,7 @@ class ClanBattleSuggestDeckListRequest(Request[ClanBattleSuggestDeckListResponse
     lap_num: int = None
     order_num: int = None
     sort_flag: int = None
+    phase: int = None
     @property
     def url(self) -> str:
         return "clan_battle/suggest_deck_list"
@@ -3645,12 +3653,225 @@ class VoteTopRequest(Request[VoteTopResponse]):
     @property
     def url(self) -> str:
         return "vote/top"
-class EquipEnhanceMaxRequest(Request[EquipEnhanceMaxResponse]):
-    unit_id: int = None
-    equip_slot_num: int = None
+class AsmFinishRequest(Request[AsmFinishResponse]):
+    from_system_id: int = None
+    play_id: int = None
+    answer_list: List[AsmAnswerInfo] = None
     @property
     def url(self) -> str:
-        return "equipment/enhance_max"
+        return ""
+class AsmReadQuizStatusRequest(Request[AsmReadQuizStatusResponse]):
+    from_system_id: int = None
+    asm_id_list: List[int] = None
+    @property
+    def url(self) -> str:
+        return ""
+class AsmStartRequest(Request[AsmStartResponse]):
+    from_system_id: int = None
+    gauge_id: int = None
+    difficulty: int = None
+    genre_id: int = None
+    mode: int = None
+    asm_type: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class AsmTopRequest(Request[AsmTopResponse]):
+    from_system_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestBattleFinishRequest(Request[BywayQuestBattleFinishResponse]):
+    quest_id: int = None
+    remain_time: int = None
+    unit_hp_list: List[UnitHpInfo] = None
+    auto_clear: int = None
+    owner_viewer_id: int = None
+    support_position: int = None
+    is_friend: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestBattleRetireRequest(Request[BywayQuestBattleRetireResponse]):
+    quest_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestBattleStartRequest(Request[BywayQuestBattleStartResponse]):
+    quest_id: int = None
+    token: str = None
+    owner_viewer_id: int = None
+    support_unit_id: int = None
+    support_battle_rarity: int = None
+    is_friend: int = None
+    auto_start_flg: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestDeliveryRequest(Request[BywayQuestDeliveryResponse]):
+    quest_id: int = None
+    item_list: List[BywayDeliveryItemInfo] = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestReplayListRequest(Request[BywayQuestReplayListResponse]):
+    quest_id: int = None
+    team_level: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestReplayRequest(Request[BywayQuestReplayResponse]):
+    quest_id: int = None
+    enc_key: str = None
+    @property
+    def url(self) -> str:
+        return ""
+class BywayQuestReplayReportRequest(Request[BywayQuestReplayReportResponse]):
+    enc_key: str = None
+    quest_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanCoinShopBuyRequest(Request[CaravanCoinShopBuyResponse]):
+    season_id: int = None
+    shop_season_id: int = None
+    slot_id_list: List[int] = None
+    current_currency_num: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanDiceRollRequest(Request[CaravanDiceRollResponse]):
+    season_id: int = None
+    current_num: int = None
+    roll_num: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanDishSellRequest(Request[CaravanDishSellResponse]):
+    season_id: int = None
+    block_id: int = None
+    dish_list: List[CaravanDishSellData] = None
+    surplus_dish_list: List[CaravanDishSellData] = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanDishUseRequest(Request[CaravanDishUseResponse]):
+    season_id: int = None
+    dish_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanGachaBlockExecRequest(Request[CaravanGachaBlockExecResponse]):
+    season_id: int = None
+    block_id: int = None
+    gacha_type: int = None
+    current_currency_num: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanMinigameCccFinishRequest(Request[CaravanMinigameCccFinishResponse]):
+    from_system_id: int = None
+    play_id: int = None
+    object_list: List[CccFinishItemCountInfo] = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanMinigameCccStartRequest(Request[CaravanMinigameCccStartResponse]):
+    from_system_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanMinigameRetireRequest(Request[CaravanMinigameRetireResponse]):
+    from_system_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanMoveRequest(Request[CaravanMoveResponse]):
+    season_id: int = None
+    current_block_id: int = None
+    block_id_list: List[int] = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanReadRequest(Request[CaravanReadResponse]):
+    season_id: int = None
+    block_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanShopBlockBuyRequest(Request[CaravanShopBlockBuyResponse]):
+    season_id: int = None
+    block_id: int = None
+    slot_id_list: List[int] = None
+    current_currency_num: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class CaravanTopRequest(Request[CaravanTopResponse]):
+    is_first: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumBattleFinishRequest(Request[ColosseumBattleFinishResponse]):
+    quest_id: int = None
+    user_unit_info: List[ColosseumBattleFinishUnitInfo] = None
+    versus_user_unit_info: List[ColosseumBattleFinishUnitInfo] = None
+    remain_time: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumBattleRetireRequest(Request[ColosseumBattleRetireResponse]):
+    quest_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumBattleStartRequest(Request[ColosseumBattleStartResponse]):
+    quest_id: int = None
+    token: str = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumHistoryRequest(Request[ColosseumHistoryResponse]):
+    quest_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumMissionAcceptRequest(Request[ColosseumMissionAcceptResponse]):
+    mission_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumMissionIndexRequest(Request[ColosseumMissionIndexResponse]):
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumRankingRequest(Request[ColosseumRankingResponse]):
+    schedule_id: int = None
+    page: int = None
+    is_my_page: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumReplayRequest(Request[ColosseumReplayResponse]):
+    quest_id: int = None
+    log_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class ColosseumTopRequest(Request[ColosseumTopResponse]):
+    @property
+    def url(self) -> str:
+        return ""
+class GachaMonthlyIndexRequest(Request[GachaMonthlyIndexResponse]):
+    @property
+    def url(self) -> str:
+        return "gacha/resident"
+class LogConnectionErrorRequest(Request[LogConnectionErrorResponse]):
+    api_name: str = None
+    error_message: str = None
+    @property
+    def url(self) -> str:
+        return ""
 class SeasonPassBuyLevelRequest(Request[SeasonPassBuyLevelResponse]):
     season_id: int = None
     current_currency_num: int = None
@@ -3678,8 +3899,83 @@ class SeasonPassRewardAcceptRequest(Request[SeasonPassRewardAcceptResponse]):
     @property
     def url(self) -> str:
         return "season_ticket_new/reward"
+class ShopBuyBulkRequest(Request[ShopBuyBulkResponse]):
+    system_id: int = None
+    buy_item_list: List[BuyBulkBuyItemList] = None
+    current_currency_num: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class SubStoryBmyReadStoryRequest(Request[SubStoryBmyReadStoryResponse]):
+    sub_story_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class SubStoryDvsReadStoryRequest(Request[SubStoryDvsReadStoryResponse]):
+    sub_story_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class SubStoryWonReadStoryRequest(Request[SubStoryWonReadStoryResponse]):
+    sub_story_id_list: List[int] = None
+    @property
+    def url(self) -> str:
+        return ""
+class SubStoryWtmReadStoryRequest(Request[SubStoryWtmReadStoryResponse]):
+    sub_story_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class SubStoryWtsReadStoryRequest(Request[SubStoryWtsReadStoryResponse]):
+    sub_story_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class TestBuyMonthlyCardRequest(Request[TestBuyMonthlyCardResponse]):
+    jewel_store_id: int = None
+    max_free_count_10: int = None
+    @property
+    def url(self) -> str:
+        return ""
 class TestBuyTicketRequest(Request[TestBuyTicketResponse]):
     season_id: int = None
     @property
     def url(self) -> str:
         return "test/buy_ticket"
+class TravelResultRoundEventRequest(Request[TravelResultRoundEventResponse]):
+    round: int = None
+    select_door_id: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class UniqueEquip2MultiEnhanceRequest(Request[UniqueEquip2MultiEnhanceResponse]):
+    unit_id: int = None
+    current_enhance_level: int = None
+    after_enhance_level: int = None
+    consume_item_list: List[EnhanceRecipe] = None
+    @property
+    def url(self) -> str:
+        return ""
+class UnitChangeMultiAutomaticModeRequest(Request[UnitChangeMultiAutomaticModeResponse]):
+    setting: int = None
+    @property
+    def url(self) -> str:
+        return ""
+class UnitChangeMultiAutomaticPromotionSettingRequest(Request[UnitChangeMultiAutomaticPromotionSettingResponse]):
+    setting: List[int] = None
+    @property
+    def url(self) -> str:
+        return ""
+class UnitGetMultiAutomaticSettingRequest(Request[UnitGetMultiAutomaticSettingResponse]):
+    @property
+    def url(self) -> str:
+        return ""
+class UnitMultiAutomaticPromotionRequest(Request[UnitMultiAutomaticPromotionResponse]):
+    unit_id_list: List[int] = None
+    target_promotion_level: int = None
+    promotion_info_list: List[MultiAutomaticPromotion] = None
+    free_promotion_unit_id_list: List[int] = None
+    current_gold: int = None
+    @property
+    def url(self) -> str:
+        return ""

--- a/autopcr/model/responses.py
+++ b/autopcr/model/responses.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 from .modelbase import ResponseBase
 from .common import *
 from .enums import *
@@ -179,6 +179,7 @@ class ClanBattleMissionIndexResponse(ResponseBase):
     daily_reset_time: int = None
 class ClanBattleMyLogDetailResponse(ResponseBase):
     lap_num: int = None
+    phase: int = None
 class ClanBattleMyLogResponse(ResponseBase):
     actual_logs: List[MyLog] = None
     rehearsal_logs: List[MyLog] = None
@@ -266,6 +267,7 @@ class ClanBattleTimelineReportResponse(ResponseBase):
     battle_end_time: int = None
     units: List[BattleTimelineUnitData] = None
     timeline: List[UnitUnionBurstTimeline] = None
+    phase: int = None
 class ClanBattleTopResponse(ResponseBase):
     clan_battle_id: int = None
     period: int = None
@@ -658,6 +660,7 @@ class GachaIndexResponse(ResponseBase):
     return_fes_gacha_point_reset: GachaPointReset = None
     current_gacha_point: int = None
     ticket_gacha_info: List[TicketGachaParameter] = None
+    resident_gacha_point_reset: GachaPointReset = None
 class GachaPrizeHistoryResponse(ResponseBase):
     gacha_prize_history_list: List[GachaPrizeHistoryList] = None
 class GachaPrizeRewardResponse(ResponseBase):
@@ -828,6 +831,7 @@ class HatsuneQuestFinishResponse(ResponseBase):
     new_sub_story_info_list: List[EventSubStoryInfo] = None
     unlock_bosses: List[HatsuneEventBossStatus] = None
     unlock_boss_id_list: List[int] = None
+    caravan_dice_point: int = None
 class HatsuneQuestRetireResponse(ResponseBase):
     pass
 class HatsuneQuestSkipResponse(ResponseBase):
@@ -849,6 +853,7 @@ class HatsuneQuestSkipResponse(ResponseBase):
     release_diary_ids: List[int] = None
     release_nyx_story_ids: List[int] = None
     new_sub_story_info_list: List[EventSubStoryInfo] = None
+    caravan_dice_point: int = None
 class HatsuneQuestStartResponse(ResponseBase):
     quest_wave_info: List[WaveEnemyInfoList] = None
     user_info: UserStaminaInfo = None
@@ -982,6 +987,8 @@ class HomeIndexResponse(ResponseBase):
     taq_banner_status: eTaqBuyStatus = None
     taq_coop_room_id: int = None
     acquired_release_coin: List[AcquiredReleaseCoin] = None
+    cleared_byway_quest_id_list: List[int] = None
+    beginner_chara_e_ticket_purchased_times: List[BeginnerCharaExchangeTicketProductData] = None
     season_ticket: SeasonPassData = None
     custom_season_pack_alert: List[int] = None
     custom_season_pack_end_time: List[int] = None
@@ -1227,7 +1234,11 @@ class LoadIndexResponse(ResponseBase):
     sdgl_start: int = None
     sdgl_end: int = None
     evmb: int = None
-    trb: int = None
+    banner_linked_pack_list: List[BannerLinkedPackList] = None
+    adc: int = None
+    receive_caravan_dice_count: int = None
+    drc: int = None
+    resident_info: MonthlyGachaInfo = None
 class LoadNextDayIndexResponse(ResponseBase):
     daily_reset_time: int = None
     login_bonus_list: LoginBonusList = None
@@ -1264,7 +1275,11 @@ class LoadNextDayIndexResponse(ResponseBase):
     tpc: int = None
     wcst: int = None
     hapi: int = None
-    trb: int = None
+    banner_linked_pack_list: List[BannerLinkedPackList] = None
+    adc: int = None
+    receive_caravan_dice_count: int = None
+    drc: int = None
+    resident_info: MonthlyGachaInfo = None
 class MirokuBattleFinishResponse(ResponseBase):
     damage_result: int = None
     attack_count: int = None
@@ -1477,6 +1492,7 @@ class QuestFinishResponse(ResponseBase):
     clan_point: ClanPoint = None
     state_exchange_stamina: eExchangeStaminaState = None
     user_gold: UserGold = None
+    caravan_dice_point: int = None
 class QuestRecoverChallengeMultipleResponse(ResponseBase):
     user_jewel: UserJewel = None
     user_quest: List[QuestRecoverInfo] = None
@@ -1510,6 +1526,7 @@ class QuestSkipMultipleResponse(ResponseBase):
     add_present_count: int = None
     clan_point: ClanPoint = None
     state_exchange_stamina: eExchangeStaminaState = None
+    caravan_dice_point: int = None
 class QuestSkipResponse(ResponseBase):
     quest_result_list: List[QuestResult] = None
     bonus_reward_list: List[InventoryInfo] = None
@@ -1526,6 +1543,7 @@ class QuestSkipResponse(ResponseBase):
     add_present_count: int = None
     clan_point: ClanPoint = None
     state_exchange_stamina: eExchangeStaminaState = None
+    caravan_dice_point: int = None
 class QuestStartResponse(ResponseBase):
     quest_wave_info: List[WaveEnemyInfoList] = None
     limit_time: int = None
@@ -1801,6 +1819,7 @@ class ShioriQuestFinishResponse(ResponseBase):
     user_gold: UserGold = None
     unlock_bosses: List[HatsuneEventBossStatus] = None
     unlock_boss_id_list: List[int] = None
+    caravan_dice_point: int = None
 class ShioriQuestRetireResponse(ResponseBase):
     pass
 class ShioriQuestSkipResponse(ResponseBase):
@@ -1820,6 +1839,7 @@ class ShioriQuestSkipResponse(ResponseBase):
     state_exchange_stamina: eExchangeStaminaState = None
     release_diary_ids: List[int] = None
     release_nyx_story_ids: List[int] = None
+    caravan_dice_point: int = None
 class ShioriQuestStartResponse(ResponseBase):
     quest_wave_info: List[WaveEnemyInfoList] = None
     user_info: UserStaminaInfo = None
@@ -2397,6 +2417,7 @@ class TravelReceiveTopEventRewardResponse(ResponseBase):
     user_jewel: UserJewel = None
     user_gold: UserGold = None
     add_present_count: int = None
+    stamina_info: UserStaminaInfo = None
 class TravelRetireResponse(ResponseBase):
     travel_result: List[TravelResult] = None
     remain_daily_retire_count: int = None
@@ -2420,6 +2441,7 @@ class TravelTopResponse(ResponseBase):
     ex_equip_id_list: List[int] = None
     campaign_list: List[TravelCampaignInfo] = None
     ex_event_still_id_list: List[int] = None
+    round_event_data: TravelAppearRoundEvent = None
 class TravelUpdatePriorityUnitListResponse(ResponseBase):
     pass
 class TrialBattleClanBattleStartResponse(ResponseBase):
@@ -2622,9 +2644,156 @@ class VoteExecResponse(ResponseBase):
 class VoteTopResponse(ResponseBase):
     voted_unit: VotedUnit = None
     ranking: VoteRanking = None
-class EquipEnhanceMaxResponse(ResponseBase):
-    unit_data: UnitData = None
-    user_jewel: UserJewel = None
+class AsmFinishResponse(ResponseBase):
+    score_result: AsmScoreResult = None
+    present_reward_list: List[AsmRewardInfo] = None
+    unlock_story_list: List[AsmUnlockStory] = None
+    memory_gauge_emblem_list: List[AsmMemoryGaugeEmblem] = None
+    completion_emblem_list: List[AsmCompletionEmblem] = None
+    add_present_count: int = None
+class AsmReadQuizStatusResponse(ResponseBase):
+    pass
+class AsmStartResponse(ResponseBase):
+    seed: int = None
+    play_id: int = None
+class AsmTopResponse(ResponseBase):
+    asm_archive_info: List[AsmArchiveInfo] = None
+    asm_memory_gauge_info: List[AsmMemoryGaugeInfo] = None
+class BywayQuestBattleFinishResponse(ResponseBase):
+    quest_id: int = None
+    clear_flag: int = None
+    result_type: int = None
+    user_gold: UserGold = None
+    add_present_count: int = None
+    reward_list: List[InventoryInfo] = None
+class BywayQuestBattleRetireResponse(ResponseBase):
+    pass
+class BywayQuestBattleStartResponse(ResponseBase):
+    seed: int = None
+    battle_log_id: int = None
+    skin_data_for_request: List[SkinDataForRequest] = None
+    support_position: int = None
+class BywayQuestDeliveryResponse(ResponseBase):
+    add_present_count: int = None
+class BywayQuestReplayListResponse(ResponseBase):
+    replay_list: List[QuestReplayData] = None
+class BywayQuestReplayResponse(ResponseBase):
+    user_unit_list: List[UnitData] = None
+    team_level: int = None
+class BywayQuestReplayReportResponse(ResponseBase):
+    pass
+class CaravanCoinShopBuyResponse(ResponseBase):
+    purchase_list: List[InventoryInfo] = None
+    item_data: List[InventoryInfo] = None
+    add_present_count: int = None
+class CaravanDiceRollResponse(ResponseBase):
+    spots_list: List[int] = None
+class CaravanDishSellResponse(ResponseBase):
+    reward_list: List[InventoryInfo] = None
+class CaravanDishUseResponse(ResponseBase):
+    event_id: int = None
+    reward_list: List[InventoryInfo] = None
+    sub_reward_list: List[InventoryInfo] = None
+    surplus_dish_list: List[CaravanDishData] = None
+    shop_block_lineup_list: List[CaravanShopBlockLineup] = None
+    add_present_count: int = None
+class CaravanGachaBlockExecResponse(ResponseBase):
+    reward_list: List[InventoryInfo] = None
+    surplus_dish_list: List[CaravanDishData] = None
+    rank_list: List[int] = None
+    add_present_count: int = None
+class CaravanMinigameCccFinishResponse(ResponseBase):
+    total_score_base: int = None
+    total_score_corrected: int = None
+    apply_event_id_list: List[int] = None
+    reward_list: List[InventoryInfo] = None
+    add_present_count: int = None
+class CaravanMinigameCccStartResponse(ResponseBase):
+    play_id: int = None
+    ccc_scenario_id: int = None
+    ccc_chara_id: int = None
+class CaravanMinigameRetireResponse(ResponseBase):
+    minigame_retire_reward: List[InventoryInfo] = None
+    add_present_count: int = None
+class CaravanMoveResponse(ResponseBase):
+    turn: int = None
+    reward_list: List[InventoryInfo] = None
+    surplus_dish_list: List[CaravanDishData] = None
+    event_id: int = None
+    default_mile_reward: int = None
+    spots: int = None
+    shop_block_lineup_list: List[CaravanShopBlockLineup] = None
+    goal_bonus_list: List[InventoryInfo] = None
+    goal_bonus_treasure_list: List[CaravanGoalBonusTreasureData] = None
+    lottery_result_list: List[InventoryInfo] = None
+    treasure_appraisal_list: List[CaravanTreasureAppraisalData] = None
+    treasure_reward_list: List[InventoryInfo] = None
+    add_present_count: int = None
+    minigame_id: int = None
+class CaravanReadResponse(ResponseBase):
+    pass
+class CaravanShopBlockBuyResponse(ResponseBase):
+    purchase_list: List[InventoryInfo] = None
+    add_present_count: int = None
+class CaravanTopResponse(ResponseBase):
+    season_id: int = None
+    turn: int = None
+    action_bit_flag: int = None
+    block_id: int = None
+    spots: int = None
+    used_dish_id: int = None
+    dish_effect_list: List[CaravanDishEffectData] = None
+    event_effect_list: List[CaravanEventEffectData] = None
+    caravan_dice_point: int = None
+    caravan_item_list: List[InventoryInfo] = None
+    treasure_list: List[CaravanTreasureData] = None
+    dish_list: List[CaravanDishData] = None
+    surplus_dish_list: List[CaravanDishData] = None
+    coin_shop_list: List[CaravanCoinShopData] = None
+    reset_reward: List[InventoryInfo] = None
+    shop_block_lineup_list: List[CaravanShopBlockLineup] = None
+    goal_reward_list: CaravanTopGoalReward = None
+    add_present_count: int = None
+    suspended_minigame_id: int = None
+    minigame_retire_reward: List[InventoryInfo] = None
+    init_reward_list: List[InventoryInfo] = None
+class ColosseumBattleFinishResponse(ResponseBase):
+    score: ColosseumScore = None
+class ColosseumBattleRetireResponse(ResponseBase):
+    pass
+class ColosseumBattleStartResponse(ResponseBase):
+    battle_log_id: int = None
+    seed: int = None
+    versus_user_unit_info: List[UnitData] = None
+class ColosseumHistoryResponse(ResponseBase):
+    history: List[ColosseumHistoryInfo] = None
+class ColosseumMissionAcceptResponse(ResponseBase):
+    rewards: List[InventoryInfo] = None
+    add_present_count: int = None
+class ColosseumMissionIndexResponse(ResponseBase):
+    missions: List[UserMissionInfo] = None
+    add_present_count: int = None
+class ColosseumRankingResponse(ResponseBase):
+    status: int = None
+    score: int = None
+    rank: int = None
+    ranking: List[ColosseumRankingInfo] = None
+class ColosseumReplayResponse(ResponseBase):
+    seed: int = None
+    team_level: int = None
+    user_unit_info: List[UnitData] = None
+    versus_user_unit_info: List[UnitData] = None
+class ColosseumTopResponse(ResponseBase):
+    schedule_id: int = None
+    acceptable_mission_count: int = None
+    scores: List[ColosseumScore] = None
+class GachaMonthlyIndexResponse(ResponseBase):
+    gacha_info: List[GachaParameter] = None
+    exchange_num: int = None
+    max_exchange_num: int = None
+    free_gacha_info: MonthlyFreeGachaInfo = None
+class LogConnectionErrorResponse(ResponseBase):
+    pass
 class SeasonPassBuyLevelResponse(ResponseBase):
     user_jewel: UserJewel = None
     seasonpass_level: int = None
@@ -2655,5 +2824,54 @@ class SeasonPassRewardAcceptResponse(ResponseBase):
     rewards: List[InventoryInfo] = None
     add_present_count: int = None
     received_rewards: List[int] = None
+class ShopBuyBulkResponse(ResponseBase):
+    purchase_list: List[InventoryInfo] = None
+    item_data: List[InventoryInfo] = None
+    user_gold: UserGold = None
+class SubStoryBmyReadStoryResponse(ResponseBase):
+    reward_info: List[InventoryInfo] = None
+    special_reward_list: List[InventoryInfo] = None
+    add_present_count: int = None
+class SubStoryDvsReadStoryResponse(ResponseBase):
+    reward_info: List[InventoryInfo] = None
+    add_present_count: int = None
+class SubStoryWonReadStoryResponse(ResponseBase):
+    reward_info: List[InventoryInfo] = None
+    new_sub_story_info_list: List[EventSubStoryInfo] = None
+    add_present_count: int = None
+class SubStoryWtmReadStoryResponse(ResponseBase):
+    reward_info: List[InventoryInfo] = None
+    special_reward_list: List[InventoryInfo] = None
+    add_present_count: int = None
+class SubStoryWtsReadStoryResponse(ResponseBase):
+    reward_info: List[InventoryInfo] = None
+    add_present_count: int = None
+class TestBuyMonthlyCardResponse(ResponseBase):
+    resident_info: MonthlyGachaInfo = None
 class TestBuyTicketResponse(ResponseBase):
     ticket_status: int = None
+class TravelResultRoundEventResponse(ResponseBase):
+    current_round_result: TravelRoundEventResult = None
+    next_round_event_data: TravelAppearRoundEvent = None
+    user_jewel: UserJewel = None
+    user_gold: UserGold = None
+    add_present_count: int = None
+class UniqueEquip2MultiEnhanceResponse(ResponseBase):
+    unit_data: UnitData = None
+    item_list: List[InventoryInfo] = None
+    user_gold: UserGold = None
+class UnitChangeMultiAutomaticModeResponse(ResponseBase):
+    pass
+class UnitChangeMultiAutomaticPromotionSettingResponse(ResponseBase):
+    pass
+class UnitGetMultiAutomaticSettingResponse(ResponseBase):
+    enhance_setting_list: List[int] = None
+    promotion_setting_list: List[int] = None
+    mode: int = None
+class UnitMultiAutomaticPromotionResponse(ResponseBase):
+    equip_list: List[InventoryInfo] = None
+    unit_data: List[UnitData] = None
+    item_data: List[InventoryInfo] = None
+    refund_items: List[InventoryInfo] = None
+    user_gold: UserGold = None
+    add_present_count: int = None

--- a/autopcr/module/accountmgr.py
+++ b/autopcr/module/accountmgr.py
@@ -184,6 +184,10 @@ class Account(ModuleManager):
     def delete(self):
         self._parent.delete(self.alias)
 
+    def is_clan_battle_forbidden(self):
+        username = self.data.username.lower()
+        return self._parent._parent.is_clan_battle_forbidden(username)
+
 class AccountManager:
     pathsyntax = re.compile(r'[^\\\|?*/]{1,32}')
 
@@ -288,6 +292,16 @@ class UserManager:
         self.root = root
         self.user_lock: Dict[str, Lock] = {}
         self.account_lock: Dict[str, Dict[str, Lock]] = {}
+        self.clan_battle_forbidden = set()
+
+    def is_clan_battle_forbidden(self, username: str) -> bool:
+        if os.path.exists(os.path.join(CONFIG_PATH, 'clan_battle_forbidden.txt')):
+            with open(os.path.join(CONFIG_PATH, 'clan_battle_forbidden.txt'), 'r') as f:
+                data = f.read().splitlines()
+                self.clan_battle_forbidden = set([x.strip().lower() for x in data])
+            return username in self.clan_battle_forbidden
+        else:
+            return False
 
     def validate_password(self, qid: str, password: str) -> bool:
         try:

--- a/autopcr/module/accountmgr.py
+++ b/autopcr/module/accountmgr.py
@@ -3,9 +3,9 @@
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 from ..core.pcrclient import pcrclient
-from .modulemgr import ModuleManager
+from .modulemgr import ModuleManager, TaskResult, ModuleResult
 import os, re, shutil
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Union
 from ..constants import CONFIG_PATH, OLD_CONFIG_PATH, RESULT_DIR
 from asyncio import Lock
 import json
@@ -13,7 +13,7 @@ from copy import deepcopy
 import hashlib
 from ..db.database import db
 import datetime
-from PIL import Image
+import traceback
 
 class AccountException(Exception):
     pass
@@ -82,11 +82,12 @@ class Account(ModuleManager):
         with open(self._filename, 'w') as f:
             f.write(self.data.to_json())
 
-    async def save_daily_result(self, result: Image.Image, status: str) -> str:
+    async def save_daily_result(self, result: TaskResult, status: str):
         now = datetime.datetime.now()
         time_safe = db.format_time_safe(now)
-        file = os.path.join(RESULT_DIR, f"{self.token}_daily_{time_safe}.jpg")
-        result.save(file, optimize=True, quality=75)
+        file = os.path.join(RESULT_DIR, f"{self.token}_daily_{time_safe}.json")
+        with open(file, 'w') as f:
+            f.write(result.to_json())
 
         old_list = self.data.daily_result
         while len(old_list) >= 4:
@@ -95,41 +96,38 @@ class Account(ModuleManager):
             old_list.pop()
         item = DailyResult(path = file, time = db.format_time(now), time_safe=time_safe, status = status)
         self.data.daily_result = [item] + old_list
-        return file
 
-    async def save_single_result(self, module: str, result: Image.Image) -> str:
-        file = os.path.join(RESULT_DIR, f"{self.token}_{module}.jpg")
-        result.save(file, optimize=True, quality=75)
-        return file
-
-    async def save_single_result_text(self, module: str, result: str) -> str:
-        file = os.path.join(RESULT_DIR, f"{self.token}_{module}.txt")
+    async def save_single_result(self, module: str, result: ModuleResult):
+        file = os.path.join(RESULT_DIR, f"{self.token}_{module}.json")
         with open(file, 'w') as f:
-            f.write(result)
-        return file
+            f.write(result.to_json())
 
-    async def get_daily_result_from_id(self, id: int = 0) -> str:
+    async def get_daily_result_from_id(self, id: int = 0) -> Union[None, TaskResult]:
         if len(self.data.daily_result) > id:
-            return self.data.daily_result[id].path
+            try:
+                with open(self.data.daily_result[id].path, 'r') as f:
+                    return TaskResult.from_json(f.read())
+            except Exception as e:
+                traceback.print_exc()
+                return None
         else:
-            return ""
+            return None
 
-    async def get_daily_result_from_time(self, safe_time: str) -> str:
+    async def get_daily_result_from_time(self, safe_time: str) -> Union[None, TaskResult]:
         ret = [daily_result.path for daily_result in self.data.daily_result if safe_time == daily_result.time_safe]
         if ret:
-            return ret[0]
+            with open(ret[0], 'r') as f:
+                return TaskResult.from_json(f.read())
         else:
-            return ""
+            return None
 
-    async def get_single_result(self, module) -> str:
-        file = os.path.join(RESULT_DIR, f"{self.token}_{module}.jpg")
-        file2 = os.path.join(RESULT_DIR, f"{self.token}_{module}.txt")
+    async def get_single_result(self, module) -> Union[None, ModuleResult]:
+        file = os.path.join(RESULT_DIR, f"{self.token}_{module}.json")
         if os.path.exists(file):
-            return file
-        elif os.path.exists(file2):
-            return file2
+            with open(file, 'r') as f:
+                return ModuleResult.from_json(f.read())
         else:
-            return ""
+            return None
 
     def get_last_daily_clean(self) -> DailyResult:
         if self.data.daily_result:
@@ -172,6 +170,14 @@ class Account(ModuleManager):
             'password': 8 * "*" if self.data.password else "",
             'area': [{"key": 'daily', "name":"日常"}, {"key": 'tools', "name":"工具"}]
         }
+
+    def generate_result_info(self):
+        ret = {
+            'name': self.alias,
+            'daily_clean_time': self.get_last_daily_clean().to_dict(),
+            'daily_clean_time_list': [daily_result.safe_info().to_dict() for daily_result in self.data.daily_result],
+            }
+        return ret
 
     def generate_daily_info(self):
         info = super().generate_daily_config()
@@ -274,11 +280,7 @@ class AccountManager:
         accounts = []
         for account in self.accounts():
             async with self.load(account, readonly = True) as acc:
-                accounts.append({
-                    'name': account,
-                    'daily_clean_time': acc.get_last_daily_clean().to_dict(),
-                    'daily_clean_time_list': [daily_result.safe_info().to_dict() for daily_result in acc.data.daily_result],
-                    })
+                accounts.append(acc.generate_result_info())
         return {
             'qq': self.qid,
             'default_account': self.default_account,

--- a/autopcr/module/modulemgr.py
+++ b/autopcr/module/modulemgr.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
-import datetime
 
 from dataclasses_json import dataclass_json
 from typing import List, Dict, Tuple
+
 from ..model.error import *
 from ..model.enums import *
 from ..db.database import db
-from .modulebase import Module, ModuleResult
-from ..util.draw import instance as drawer
+from .modulebase import Module, ModuleResult, ModuleStatus
 
 import traceback
 
@@ -22,10 +21,11 @@ class ModuleManager:
 
     def __init__(self, config, parent):
         from .modules import daily_modules, tool_modules, cron_modules, hidden_modules
+        from .modules.cron import CronModule
         from .accountmgr import Account
 
         self.parent: Account = parent
-        self.cron_modules: List[Module] = [m(self) for m in cron_modules]
+        self.cron_modules: List[CronModule] = [m(self) for m in cron_modules]
         self.daily_modules: List[Module] = [m(self) for m in daily_modules]
         self.tool_modules: List[Module] = [m(self) for m in tool_modules]
         self.hidden_modules: List[Module] = [m(self) for m in hidden_modules]
@@ -52,12 +52,13 @@ class ModuleManager:
             traceback.print_exc()
             raise
     
-    def is_cron_run(self, nhour, nminute):
-        clan_battle_time = db.is_clan_battle_time()
-        for hour, minute, is_clan_battle_run in self._crons:
-            if hour == nhour and minute == nminute and (is_clan_battle_run or not clan_battle_time):
+    async def is_cron_run(self, hour: int, minute: int) -> bool:
+        for cron in self.cron_modules:
+            if await cron.is_cron_run(hour, minute):
+                await cron.update_client(self.client)
                 return True
-        return False
+        else:
+            return False
     
     def get_config(self, name, default):
         return self.client.keys.get(name, default)
@@ -75,20 +76,17 @@ class ModuleManager:
     def generate_tools_config(self):
         return self.generate_config(self.tool_modules)
     
-    async def do_daily(self, isAdminCall: bool = False) -> Tuple[str, str]:
-        status = "success"
-        try:
-            resp = await self.do_task(self.client.keys, self.daily_modules, isAdminCall)
-            img = await drawer.draw_tasks_result(resp)
-            status = "error" if any(r.status == "error" for r in resp.result.values()) else status
-        except Exception as e:
-            traceback.print_exc()
-            img = await drawer.draw_msgs([self.parent.qq, self.parent.alias, str(e)])
-            status = "error"
-        file_path = await self.parent.save_daily_result(img, status)
-        return file_path, status
+    async def do_daily(self, isAdminCall: bool = False) -> Tuple[TaskResult, ModuleStatus]:
+        resp = await self.do_task(self.client.keys, self.daily_modules, isAdminCall)
+        status = ModuleStatus.success
+        if any(m.status == ModuleStatus.warning or m.status == ModuleStatus.abort for m in resp.result.values()):
+            status = ModuleStatus.warning
+        if any(m.status == ModuleStatus.panic or m.status == ModuleStatus.error for m in resp.result.values()):
+            status = ModuleStatus.error
+        await self.parent.save_daily_result(resp, status.value)
+        return resp, status
 
-    async def do_from_key(self, config: dict, key: str, isAdminCall: bool = False) -> str:
+    async def do_from_key(self, config: dict, key: str, isAdminCall: bool = False) -> Tuple[ModuleResult, str]:
         config.update({
             key: True,
             "stamina_relative_not_run": False
@@ -96,17 +94,12 @@ class ModuleManager:
         modules = [self.name_to_modules[key]]
         raw_resp = await self.do_task(config, modules, isAdminCall)
         resp = raw_resp.result[key] 
-
-        if modules[0].text_result:
-            file_path = await self.parent.save_single_result_text(key, resp.log)
-        else:
-            img = await drawer.draw_task_result(resp)
-            file_path = await self.parent.save_single_result(key, img)
-        return file_path
+        await self.parent.save_single_result(key, resp)
+        return resp, resp.status.value
 
     async def do_task(self, config: dict, modules: List[Module], isAdminCall: bool = False) -> TaskResult:
         if db.is_clan_battle_time() and self.parent.is_clan_battle_forbidden() and not isAdminCall:
-            raise ValueError("会战期间禁止执行任务")
+            raise PanicError("会战期间禁止执行任务")
 
         client = self.client
         client.keys["stamina_relative_not_run"] = any(db.is_campaign(campaign) for campaign in client.keys.get("stamina_relative_not_run_campaign_before_one_day", []))
@@ -114,15 +107,13 @@ class ModuleManager:
         client.keys.update(config)
 
         resp: TaskResult = TaskResult(
-                order = [m.key for m in modules],
+                order = [],
                 result = {}
         )
-        try:
-            await client.login()
-            for module in modules:
-                resp.result[module.__class__.__name__] = await module.do_from(client)
-        except Exception as e:
-            traceback.print_exc()
-            raise(e)
+        for module in modules:
+            resp.order.append(module.key)
+            resp.result[module.key] = await module.do_from(client)
+            if resp.result[module.key].status == ModuleStatus.panic:
+                break
         return resp
 

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -17,6 +17,8 @@ cron_modules = [
     cron2,
     cron3,
     cron4,
+    cron5,
+    cron6,
 ]
 
 daily_modules = [

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -27,6 +27,7 @@ daily_modules = [
     room_like_back,
     free_gacha,
     normal_gacha,
+    monthly_gacha,
     room_accept_all,
     explore_exp,
     explore_mana,

--- a/autopcr/module/modules/clan.py
+++ b/autopcr/module/modules/clan.py
@@ -10,7 +10,7 @@ from ...db.database import db
 @description('在公会中自动随机选择一位成员点赞。')
 @name("公会点赞")
 @default(True)
-@stamina_relative
+@tag_stamina_get
 class clan_like(Module):
     async def do_task(self, client: pcrclient):
         if client.data.clan_like_count:
@@ -20,7 +20,7 @@ class clan_like(Module):
             raise AbortError("未加入公会")
         info = clan.clan
         members = [(x.viewer_id, x.name) for x in info.members if x.viewer_id != client.viewer_id]
-        if len(members) == 0: raise AbortError("No other members in clan")
+        if len(members) == 0: raise AbortError("nobody's home?")
         rnd = random.choice(members)
         await client.clan_like(rnd[0])
         self._log(f"为【{rnd[1]}】点赞")

--- a/autopcr/module/modules/cron.py
+++ b/autopcr/module/modules/cron.py
@@ -3,6 +3,36 @@ from ..config import *
 from ...core.pcrclient import pcrclient
 from ...model.error import *
 from ...model.enums import *
+from ...db.database import db
+
+class CronModule(Module):
+    def get_cron_time(self) -> str: ...
+
+    async def is_cron_condition(self) -> bool: ...
+
+    async def is_cron_time(self, nhour: int, nminute: int) -> bool:
+        time = self.get_cron_time()
+        hour, minute = time.split(":")
+        return nhour == int(hour) and nminute == int(minute)
+
+    async def update_client(self, client: pcrclient):
+        client.set_cron_run()
+
+    async def is_cron_run(self, hour: int, minute: int) -> bool:
+        enable: bool = self.get_config(self.key)
+        if enable and await self.is_cron_time(hour, minute) and await self.is_cron_condition():
+            return True
+        else:
+            return False
+
+class NormalCronModule(CronModule):
+    def get_clanbattle_run_status(self) -> bool: ...
+
+    async def is_cron_condition(self) -> bool:
+        is_clan_battle_run = self.get_clanbattle_run_status()
+        is_clan_battle_time = db.is_clan_battle_time()
+        return not is_clan_battle_time or is_clan_battle_run
+
 
 @timetype("time_cron1", "执行时间", "00:00")
 @booltype("clanbattle_run_cron1", "会战期间执行", False)
@@ -10,9 +40,11 @@ from ...model.enums import *
 @name("定时任务1")
 @default(False)
 @notrunnable
-class cron1(Module):
-    async def do_task(self, client: pcrclient):
-        pass
+class cron1(NormalCronModule):
+    def get_cron_time(self) -> str:
+        return self.get_config("time_cron1")
+    def get_clanbattle_run_status(self) -> bool:
+        return self.get_config("clanbattle_run_cron1")
 
 @timetype("time_cron2", "执行时间", "00:00")
 @booltype("clanbattle_run_cron2", "会战期间执行", False)
@@ -20,9 +52,11 @@ class cron1(Module):
 @name("定时任务2")
 @default(False)
 @notrunnable
-class cron2(Module):
-    async def do_task(self, client: pcrclient):
-        pass
+class cron2(NormalCronModule):
+    def get_cron_time(self) -> str:
+        return self.get_config("time_cron2")
+    def get_clanbattle_run_status(self) -> bool:
+        return self.get_config("clanbattle_run_cron2")
 
 
 @timetype("time_cron3", "执行时间", "00:00")
@@ -31,9 +65,11 @@ class cron2(Module):
 @name("定时任务3")
 @default(False)
 @notrunnable
-class cron3(Module):
-    async def do_task(self, client: pcrclient):
-        pass
+class cron3(NormalCronModule):
+    def get_cron_time(self) -> str:
+        return self.get_config("time_cron3")
+    def get_clanbattle_run_status(self) -> bool:
+        return self.get_config("clanbattle_run_cron3")
 
 @timetype("time_cron4", "执行时间", "00:00")
 @booltype("clanbattle_run_cron4", "会战期间执行", False)
@@ -41,7 +77,46 @@ class cron3(Module):
 @name("定时任务4")
 @default(False)
 @notrunnable
-class cron4(Module):
-    async def do_task(self, client: pcrclient):
-        pass
+class cron4(NormalCronModule):
+    def get_cron_time(self) -> str:
+        return self.get_config("time_cron4")
+    def get_clanbattle_run_status(self) -> bool:
+        return self.get_config("clanbattle_run_cron4")
 
+@timetype("time_cron5", "执行时间", "00:00")
+@description('该定时任务不执行体力消耗的操作')
+@name("特别定时任务1")
+@default(False)
+@conditional_execution2('run_condition_cron5', [], desc='执行庆典', check=False)
+@notrunnable
+class cron5(CronModule):
+    def get_cron_time(self) -> str:
+        return self.get_config("time_cron5")
+
+    async def is_cron_condition(self) -> bool:
+        condition = self.get_config_instance("run_condition_cron5")
+        ok, _ = await condition.do_check()
+        return ok
+
+    async def update_client(self, client: pcrclient):
+        await super().update_client(client)
+        client.set_stamina_consume_not_run()
+
+@timetype("time_cron6", "执行时间", "00:00")
+@description('该定时任务不执行体力获取的操作')
+@name("特别定时任务2")
+@default(False)
+@conditional_execution2('run_condition_cron6', [], desc='执行庆典', check=False)
+@notrunnable
+class cron6(CronModule):
+    def get_cron_time(self) -> str:
+        return self.get_config("time_cron6")
+
+    async def is_cron_condition(self) -> bool:
+        condition = self.get_config_instance("run_condition_cron6")
+        ok, _ = await condition.do_check()
+        return ok
+
+    async def update_client(self, client: pcrclient):
+        await super().update_client(client)
+        client.set_stamina_get_not_run()

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -11,7 +11,7 @@ from ...util.questutils import *
 import asyncio
 import datetime
 
-@description('全局生效，氪体数优先级n4>n3>h3>n2>h2，禅模式指不执行体力相关的功能，仅在清日常生效，单项执行将忽略。庆典包括其倍数')
+@description('仅开启时生效，氪体数优先级n4>n3>h3>vh3>n2>h2>vh2，禅模式指不执行体力相关的功能，仅在清日常生效，单项执行将忽略。庆典包括其倍数')
 @name("全局配置")
 @default(True)
 @inttype('sweep_recover_stamina_times', "平时氪体数", 0, [i for i in range(41)])
@@ -20,13 +20,67 @@ import datetime
 @inttype('sweep_recover_stamina_times_n4', "n4以上氪体数", 0, [i for i in range(41)])
 @inttype('sweep_recover_stamina_times_h2', "h2氪体数", 0, [i for i in range(41)])
 @inttype('sweep_recover_stamina_times_h3', "h3以上氪体数", 0, [i for i in range(41)])
+@inttype('sweep_recover_stamina_times_vh2', "vh2氪体数", 0, [i for i in range(41)])
+@inttype('sweep_recover_stamina_times_vh3', "vh3以上氪体数", 0, [i for i in range(41)])
 @conditional_not_execution("force_stop_heart_sweep", [], desc="不刷心碎庆典", check=False)
 @conditional_not_execution("force_stop_star_cup_sweep", [], desc="不刷星球杯庆典", check=False)
-@multichoice('stamina_relative_not_run_campaign_before_one_day', "禅模式", [], ['n3以上前夕','n3以上首日午前','h3以上前夕','会战前夕','会战期间'])
+@conditional_execution2('stamina_relative_not_run_campaign_before_one_day', [], desc='禅模式', check=False)
 @notrunnable
 class global_config(Module):
-    async def do_task(self, client: pcrclient):
-        pass
+    async def do_task(self, client: pcrclient): # stamina TODO
+        if client.is_cron_run():
+            self._log("执行定时任务")
+
+        stamina_check = [('sweep_recover_stamina_times_n4', 
+                          lambda: client.data.is_normal_quest_campaign() and client.data.get_normal_quest_campaign_times() >= 4),
+                         ('sweep_recover_stamina_times_n3',
+                          lambda: client.data.is_normal_quest_campaign() and client.data.get_normal_quest_campaign_times() == 3),
+                         ('sweep_recover_stamina_times_h3',
+                          lambda: client.data.is_hard_quest_campaign() and client.data.get_hard_quest_campaign_times() >= 3),
+                         ('sweep_recover_stamina_times_vh3',
+                          lambda: client.data.is_very_hard_quest_campaign() and client.data.get_very_hard_quest_campaign_times() >= 3),
+                         ('sweep_recover_stamina_times_n2',
+                          lambda: client.data.is_normal_quest_campaign() and client.data.get_normal_quest_campaign_times() == 2),
+                         ('sweep_recover_stamina_times_h2',
+                          lambda: client.data.is_hard_quest_campaign() and client.data.get_hard_quest_campaign_times() == 2),
+                         ('sweep_recover_stamina_times_vh2',
+                          lambda: client.data.is_very_hard_quest_campaign() and client.data.get_very_hard_quest_campaign_times() == 2),
+                         ('sweep_recover_stamina_times',
+                          lambda: True)
+        ]
+        for key, check in stamina_check:
+            if check():
+                stamina: int = self.get_config(key)
+                campaign = key.split('_')[-1]
+                campaign = '无庆典' if campaign == 'times' else campaign
+                client.set_stamina_recover_cnt(stamina)
+                self._log(f"今日{campaign}，氪体数{stamina}")
+                break
+
+        force_stop_star_cup_sweep = self.get_config_instance('force_stop_star_cup_sweep')
+        ok, msg = await force_stop_star_cup_sweep.do_check(client)
+        if not ok:
+            client.set_star_cup_sweep_not_run()
+            self._log(msg + "星球杯扫荡")
+
+        force_stop_heart_sweep = self.get_config_instance('force_stop_heart_sweep')
+        ok, msg = await force_stop_heart_sweep.do_check(client)
+        if not ok:
+            client.set_heart_sweep_not_run()
+            self._log(msg + "心碎扫荡")
+
+        if client.is_stamina_get_not_run():
+            self._log("体力获取不执行")
+        elif client.is_stamina_consume_not_run():
+            self._log("体力消耗不执行")
+        else:
+            stamina_relative_not_run_campaign_before_one_day = self.get_config_instance('stamina_relative_not_run_campaign_before_one_day')
+            ok, msg = await stamina_relative_not_run_campaign_before_one_day.do_check()
+            if ok:
+                client.set_stamina_get_not_run()
+                client.set_stamina_consume_not_run()
+                self._log(msg + "禅模式")
+
 
 @description('选谁其实排名都一样的')
 @name("赛马")
@@ -43,7 +97,7 @@ class chara_fortune(Module):
 @description('开始时领取任务奖励')
 @name("领取每日任务奖励1")
 @default(True)
-@stamina_relative
+@tag_stamina_get
 class mission_receive_first(Module):
     async def do_task(self, client: pcrclient):
         resp = await client.mission_index()
@@ -58,7 +112,7 @@ class mission_receive_first(Module):
 @description('结束时领取任务奖励')
 @name("领取每日任务奖励2")
 @default(True)
-@stamina_relative
+@tag_stamina_get
 class mission_receive_last(Module):
     async def do_task(self, client: pcrclient):
         resp = await client.mission_index()
@@ -93,7 +147,7 @@ class seasonpass_accept(Module):
 @booltype('seasonpass_reward_stamina_exclude', "不领取体力", True)
 @name("领取女神祭奖励")
 @default(True)
-@stamina_relative
+@tag_stamina_get
 class seasonpass_reward(Module):
 
     class Reward:
@@ -159,7 +213,7 @@ class seasonpass_reward(Module):
 @description('领取符合条件的所有礼物箱奖励')
 @name('领取礼物箱')
 @default(True)
-@stamina_relative
+@tag_stamina_get
 class present_receive(Module):
     async def do_task(self, client: pcrclient):
         if self.get_config('present_receive_strategy') == "非体力":
@@ -268,7 +322,18 @@ class pjjc_daily(Module):
 class user_info(Module):
     async def do_task(self, client: pcrclient):
         now = db.format_time(datetime.datetime.now())
-        self._log(f"{client.data.name} 体力{client.data.stamina}({db.team_info[client.data.team_level].max_stamina}) 等级{client.data.team_level} 钻石{client.data.jewel.free_jewel} mana{client.data.gold.gold_id_free} 扫荡券{client.data.get_inventory((eInventoryType.Item, 23001))} 母猪石{client.data.get_inventory((eInventoryType.Item, 90005))}")
+        name = client.data.name
+        level = client.data.team_level
+        stamina = client.data.stamina
+        max_stamina = db.team_info[client.data.team_level].max_stamina
+        jewel = client.data.jewel.free_jewel
+        mana = client.data.gold.gold_id_free
+        sweep_ticket = client.data.get_inventory((eInventoryType.Item, 23001))
+        pig = client.data.get_inventory((eInventoryType.Item, 90005))
+
+        if stamina >= max_stamina:
+            self._warn(f"体力爆了！")
+        self._log(f"{name} 体力{stamina}({max_stamina}) 等级{level} 钻石{jewel} mana{mana} 扫荡券{sweep_ticket} 母猪石{pig}")
         self._log(f"已购买体力数：{client.data.recover_stamina_exec_count}")
-        self._log(f"清日常时间:{now}")
+        self._log(f"清日常时间：{now}")
 

--- a/autopcr/module/modules/hatsune.py
+++ b/autopcr/module/modules/hatsune.py
@@ -12,10 +12,10 @@ from ...model.enums import *
 @description('')
 @name('扫荡活动h本')
 @default(False)
-@stamina_relative
+@tag_stamina_consume
 class hatsune_h_sweep(Module):
     async def do_task(self, client: pcrclient):
-        area = self.get_config('hatsune_h_sweep_quest')
+        area: List[int] = self.get_config('hatsune_h_sweep_quest')
         not_sweep_hatsune: List[str] = self.get_config('hatsune_h_sweep_not_event')
         not_sweep_hatsune_id = set(int(event.split(':')[0]) for event in not_sweep_hatsune)
         hard = 200
@@ -26,7 +26,6 @@ class hatsune_h_sweep(Module):
         for event in db.get_active_hatsune():
             event_name = db.event_name[event.event_id]
             self._log(f"{event.event_id}:{event_name}：")
-            print(not_sweep_hatsune_id, event.event_id)
             if event.event_id in not_sweep_hatsune_id:
                 self._log(f"不扫荡h本")
                 continue
@@ -58,7 +57,7 @@ class hatsune_h_sweep(Module):
 @multichoice("hatsune_hboss_strategy", "扫荡策略", ["保留今日vh", "保留未来vh","保留sp"], ["保留今日vh", "保留未来vh","保留sp"])
 @description('vh保留30，sp保留90，若无通关则会保留')
 @name('扫荡活动h本boss')
-@default("none")
+@default(True)
 class hatsune_hboss_sweep(Module):
     async def do_task(self, client: pcrclient):
         strategy: List[str] = self.get_config('hatsune_hboss_strategy')
@@ -220,7 +219,7 @@ class hatsune_mission_accept2(hatsune_mission_accept_base):
 @description('剩余体力全部刷活动图')
 @name('全刷活动普图')
 @default(False)
-@stamina_relative
+@tag_stamina_consume
 class all_in_hatsune(Module):
     async def do_task(self, client: pcrclient):
         quest = 0
@@ -244,7 +243,9 @@ class all_in_hatsune(Module):
 
         count = client.data.stamina // db.quest_info[quest].stamina
 
-        if count == 0: raise AbortError("体力不足")
-        await client.quest_skip_aware(quest, count)
-        self._log(f"已刷{quest}图{count}次")
+        if count == 0: 
+            self._log("体力不足")
+        else:
+            await client.quest_skip_aware(quest, count)
+            self._log(f"已刷{quest}图{count}次")
 

--- a/autopcr/module/modules/story.py
+++ b/autopcr/module/modules/story.py
@@ -70,7 +70,8 @@ class main_story_reading(Module):
         for story in db.main_story:
             if story.story_id not in read_story and story.pre_story_id in read_story:
                 if not await client.unlock_quest_id(story.unlock_quest_id):
-                    raise AbortError(f"区域{story.unlock_quest_id}未通关，无法观看{story.title}\n")
+                    self._log(f"区域{story.unlock_quest_id}未通关，无法观看{story.title}\n")
+                    break
                 await client.read_story(story.story_id)
                 read_story.add(story.story_id)
                 self._log(f"阅读了{story.title}")
@@ -94,7 +95,8 @@ class tower_story_reading(Module):
             if story.story_id not in read_story and story.pre_story_id in read_story:
                 if not await client.unlock_quest_id(story.unlock_quest_id):
                     floor_num = db.tower_quest[story.unlock_quest_id].floor_num if story.unlock_quest_id in db.tower_quest else 0
-                    raise AbortError(f"层数{floor_num}未通关，无法观看{story.title}\n")
+                    self._log(f"层数{floor_num}未通关，无法观看{story.title}\n")
+                    break
                 await client.read_story(story.story_id)
                 read_story.add(story.story_id)
                 self._log(f"阅读了{story.title}")
@@ -147,7 +149,7 @@ class hatsune_sub_story_reading(Module):
         for sub_storys in client.data.event_sub_story.values() or []:
             reader = GetSubStoryReader(sub_storys, client)
             if not reader:
-                self._log(f"暂不支持的活动{db.event_name[sub_storys.event_id]}")
+                self._warn(f"暂不支持的活动{db.event_name[sub_storys.event_id]}")
                 continue
 
             if any(sub_story.status == eEventSubStoryStatus.ADDED for sub_story in sub_storys.sub_story_info_list):

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -60,6 +60,7 @@ class UnitController(Module):
     # md python 没有引用
     async def unit_skill_up_aware(self, location: eSkillLocationCategory, skill: Callable[[], SkillLevelInfo], target_skill_level: int, limit: Union[None, GrowthParameter] = None):
         if limit and limit.skill_level < target_skill_level:
+            raise AbortError(f"{db.get_unit_name(self.unit.id)}技能{self.skill_name[location]}超过了免费可提升等级{limit.skill_level}，请自行完成免费可提升的所有内容")
             self._log(f"{db.get_unit_name(self.unit.id)}技能{self.skill_name[location]}超过了免费可提升等级{limit.skill_level},先提升至等级{limit.skill_level}")
             await self.unit_skill_up_aware(location, skill, limit.skill_level, limit)
 
@@ -99,6 +100,7 @@ class UnitController(Module):
 
     async def unit_promotion_up_aware(self, target_promotion_level: int, limit: Union[None, GrowthParameter]):
         if limit and target_promotion_level > limit.promotion_level:
+            raise AbortError(f"目标品级{target_promotion_level}超过了免费可提升品级{limit.promotion_level}，请自行完成免费可提升的所有内容")
             self._log(f"目标品级{target_promotion_level}超过了免费可提升品级{limit.promotion_level},先提升至品级{limit.promotion_level}")
             await self.unit_promotion_up_aware(limit.promotion_level, limit)
 
@@ -127,6 +129,7 @@ class UnitController(Module):
 
     async def unit_level_up_aware(self, target_level: int, limit: Union[GrowthParameter, None] = None):
         if limit and target_level > limit.unit_level:
+                raise AbortError(f"目标等级{target_level}超过了免费可提升等级{limit.unit_level}，请自行完成免费可提升的所有内容")
                 self._log(f"目标等级{target_level}超过了免费可提升等级{limit.unit_level},先提升至等级{limit.unit_level}")
                 await self.unit_level_up_aware(limit.unit_level, limit)
 

--- a/autopcr/util/draw.py
+++ b/autopcr/util/draw.py
@@ -1,4 +1,4 @@
-import os
+import os, io
 from typing import List
 from PIL import Image, ImageFont 
 from ..constants import DATA_DIR
@@ -18,10 +18,12 @@ class Drawer():
             'font': '#DFE2E6',
             'rowline': 'white',
             'colline': 'white',
-            'success': '#255035',
-            'skip': '#35778D',
-            'abort': '#937526',
-            'error': '#79282C',
+            '成功': '#255035',
+            '跳过': '#35778D',
+            '警告': '#FF8C00',
+            '中止': '#937526',
+            '错误': '#79282C',
+            '致命': '#8B0000',
         }
 
     def light_color(self):
@@ -33,10 +35,12 @@ class Drawer():
             'font': 'black',
             'rowline': 'black',
             'colline': 'black',
-            'success': '#E1FFB5',
-            'skip': '#C8D6FA',
-            'abort': 'yellow',
-            'error': 'red',
+            '成功': '#E1FFB5',
+            '跳过': '#C8D6FA',
+            '警告': '#FFD700',
+            '中止': 'yellow',
+            '错误': 'red',
+            '致命': '#8B0000',
         }
 
     def color(self):
@@ -62,12 +66,12 @@ class Drawer():
             if value.log == "功能未启用":
                 continue
             cnt += 1
-            content.append([str(cnt), value.name.strip(), value.config.strip(), "#"+value.status.strip(), value.log.strip()])
+            content.append([str(cnt), value.name.strip(), value.config.strip(), "#"+value.status.value, value.log.strip()])
         img = await self.draw(header, content)
         return img
 
     async def draw_task_result(self, data: "ModuleResult") -> Image.Image:
-        content = [["配置", data.config.strip()], ["状态", "#"+data.status.strip()], ["结果", data.log.strip()]]
+        content = [["配置", data.config.strip()], ["状态", "#"+data.status.value], ["结果", data.log.strip()]]
         header = ["名字", data.name.strip()]
         img = await self.draw(header, content)
         return img
@@ -92,5 +96,11 @@ class Drawer():
             x_offset += img.size[0]
 
         return new_image
+    
+    async def img2bytesio(self, img: Image.Image) -> io.BytesIO:
+        img_byte_arr = io.BytesIO()
+        img.save(img_byte_arr, format='JPEG')
+        img_byte_arr.seek(0)
+        return img_byte_arr
 
 instance = Drawer()

--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Any, Callable, Coroutine, Dict, List
+from typing import Any, Callable, Coroutine, Dict, List, Tuple
 
 from .autopcr.util.draw_table import outp_b64
 from .autopcr.http_server.httpserver import HttpServer
@@ -97,6 +97,7 @@ class BotEvent:
     async def send_qq(self) -> str: ...
     async def message(self) -> List[str]: ...
     async def is_admin(self) -> bool: ...
+    async def get_group_member_list(self) -> List: ...
 
 class HoshinoEvent(BotEvent):
     def __init__(self, bot: HoshinoBot, ev: CQEvent):
@@ -112,7 +113,12 @@ class HoshinoEvent(BotEvent):
                 self.at_sb.append(str(m.data['qq']))
             elif m.type == 'text': # ignore other type
                 self._message += m.data['text'].split()
-        print(self._message)
+
+    async def get_group_member_list(self) -> List[Tuple[str, str]]: # (qq, nick_name)
+        members = await self.bot.get_group_member_list(group_id=self.ev.group_id)
+        ret = [(str(m['user_id']), m['card'] if m['card'] else m['nickname']) for m in members]
+        ret = sorted(ret, key=lambda x: x[1])
+        return ret
 
     async def target_qq(self):
         if len(self.at_sb) > 1:
@@ -284,9 +290,10 @@ async def clean_daily_all(botev: BotEvent, accmgr: AccountManager):
     loop = asyncio.get_event_loop()
     task = []
     alias = []
+    is_admin_call = await botev.is_admin()
     async def clean_daily_pre(alias: str):
         async with accmgr.load(alias) as acc:
-            return await clean_daily(botev, acc)
+            return await clean_daily(botev, acc, is_admin_call)
 
     for acc in accmgr.accounts():
         alias.append(escape(acc))
@@ -308,6 +315,43 @@ async def clean_daily_all(botev: BotEvent, accmgr: AccountManager):
     if err:
         msg = "\n".join([f"{a}: {m}" for a, m in err])
         await botev.send(msg)
+
+@sv.on_fullmatch(f"{prefix}查禁用")
+@wrap_hoshino_event
+async def query_clan_battle_forbidden(botev: BotEvent):
+    if not await botev.is_admin():
+        await botev.finish("仅管理员可以调用")
+
+    content = ["会战期间仅管理员调用"]
+    for qq in usermgr.qids():
+        async with usermgr.load(qq, readonly=True) as accmgr:
+            for alias in accmgr.accounts():
+                async with accmgr.load(alias, readonly=True) as acc:
+                    if acc.is_clan_battle_forbidden():
+                        content.append(f"{acc.qq}  {acc.alias} ")
+    img = outp_b64(await drawer.draw_msgs(content))
+    await botev.finish(img)
+
+@sv.on_fullmatch(f"{prefix}查群禁用")
+@wrap_hoshino_event
+async def query_group_clan_battle_forbidden(botev: BotEvent):
+    if not await botev.is_admin():
+        await botev.finish("仅管理员可以调用")
+
+    content = []
+    header = ["昵称", "QQ", "账号", "会战调用"]
+    members = await botev.get_group_member_list()
+    for qq, name in members:
+        if qq in usermgr.qids():
+            async with usermgr.load(qq, readonly=True) as accmgr:
+                for alias in accmgr.accounts():
+                    async with accmgr.load(alias, readonly=True) as acc:
+                        msg = "仅限管理员" if acc.is_clan_battle_forbidden() else ""
+                        content.append([name, qq, alias, msg])
+        else:
+            content.append([name, qq, "" ,""])
+    img = outp_b64(await drawer.draw(header, content))
+    await botev.finish(img)
 
 @sv.on_fullmatch(f"{prefix}查内鬼")
 @wrap_hoshino_event
@@ -348,17 +392,18 @@ async def clean_daily_from(botev: BotEvent, acc: Account):
         print(e)
 
     try:
-        img = await clean_daily(botev = botev, acc = acc)
+        is_admin_call = await botev.is_admin()
+        img = await clean_daily(botev = botev, acc = acc, is_admin_call = is_admin_call)
         msg = f"{alias}"
         msg += outp_b64(img)
         await botev.send(msg)
     except Exception as e:
         await botev.send(f'{alias}: {e}')
 
-async def clean_daily(botev: BotEvent, acc: Account):
+async def clean_daily(botev: BotEvent, acc: Account, is_admin_call = False):
     loop = asyncio.get_event_loop()
     loop.create_task(check_validate(botev, acc))
-    img, _ = await acc.do_daily()
+    img, _ = await acc.do_daily(is_admin_call)
     return img
 
 @sv.on_prefix(f"{prefix}日常报告")
@@ -451,7 +496,8 @@ async def tool_used(botev: BotEvent, tool: ToolInfo, config: Dict[str, str], acc
         loop = asyncio.get_event_loop()
         loop.create_task(check_validate(botev, acc))
 
-        img = await acc.do_from_key(config, tool.key)
+        is_admin_call = await botev.is_admin()
+        img = await acc.do_from_key(config, tool.key, is_admin_call)
         msg = f"{alias}"
         msg += outp_b64(img)
         await botev.send(msg)


### PR DESCRIPTION
- ⚠️本次需更新网页资源至1.0.4
- 更新model
- 重构定时任务模块，将定时任务相关操作移至定时任务类里
- 新增【特别定时任务1】和【特别定时任务2】，将执行除体力消耗或体力获取外的任务
- 重构全局配置模块，会显示全局配置的生效情况，且开关全局配置会影响其是否生效
- 【全局配置】新增【vh2氪体数】和【vh3及以上氪体数】。
- 日常结果保存更改为文本，实时绘图
- 优化【#清日常所有】结果显示，仅显示最后一个模块的结果（一般是用户的基本信息）
- 优化定时日志（需手动情况先前日志文本），新增部分定时日志的指令，便于查看
- 新增【凭证扭蛋】功能，购买凭证月卡后会每天抽取一次免费单抽。默认启用
- 优化模块标签
- 修复小屋升级家具金币不足的错误