### PR TITLE
some fixes

### DIFF
--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -947,4 +947,13 @@ class database():
     def unit_level_candidate(self):
         return list(range(1, self.team_max_level + 1 + 10))
 
+    def last_normal_quest_candidate(self):
+        last_start_time = flow(self.normal_quest_data.values()) \
+                .where(lambda x: db.parse_time(x.start_time) <= datetime.datetime.now()) \
+                .max(lambda x: x.start_time).start_time
+        return flow(self.normal_quest_data.values()) \
+                .where(lambda x: x.start_time == last_start_time) \
+                .select(lambda x: f"{x.quest_id}: {x.quest_name.split(' ')[1]}") \
+                .to_list()
+
 db = database()

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -302,7 +302,7 @@ class LoadIndexResponse(responses.LoadIndexResponse):
 @handles
 class HomeIndexResponse(responses.HomeIndexResponse):
     async def update(self, mgr: datamgr, request):
-        mgr.finishedQuest = set([q.quest_id for q in self.quest_list if q.result_type > 0] if self.quest_list else [] + [q.quest_id for q in self.shiori_quest_info.quest_list if q.result_type > 0] if self.shiori_quest_info and self.shiori_quest_info.quest_list else [])
+        mgr.finishedQuest = set([q.quest_id for q in self.quest_list if q.result_type > 0 and q.clear_flg == 3] if self.quest_list else [] + [q.quest_id for q in self.shiori_quest_info.quest_list if q.result_type > 0] if self.shiori_quest_info and self.shiori_quest_info.quest_list else [])
         mgr.clan = self.user_clan.clan_id
         mgr.donation_num = self.user_clan.donation_num
         mgr.dungeon_area_id = self.dungeon_info.enter_area_id

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -302,7 +302,7 @@ class LoadIndexResponse(responses.LoadIndexResponse):
 @handles
 class HomeIndexResponse(responses.HomeIndexResponse):
     async def update(self, mgr: datamgr, request):
-        mgr.finishedQuest = set([q.quest_id for q in self.quest_list if q.result_type > 0 and q.clear_flg == 3] if self.quest_list else [] + [q.quest_id for q in self.shiori_quest_info.quest_list if q.result_type > 0] if self.shiori_quest_info and self.shiori_quest_info.quest_list else [])
+        mgr.finishedQuest = set([q.quest_id for q in self.quest_list if q.result_type > 0 and q.clear_flg == 3] if self.quest_list else [] + [q.quest_id for q in self.shiori_quest_info.quest_list if q.result_type > 0 and q.clear_flg == 3] if self.shiori_quest_info and self.shiori_quest_info.quest_list else [])
         mgr.clan = self.user_clan.clan_id
         mgr.donation_num = self.user_clan.donation_num
         mgr.dungeon_area_id = self.dungeon_info.enter_area_id

--- a/autopcr/module/accountmgr.py
+++ b/autopcr/module/accountmgr.py
@@ -287,7 +287,7 @@ class AccountManager:
         return {
             'qq': self.qid,
             'default_account': self.default_account,
-            'accounts': accounts
+            'accounts': sorted(accounts, key=lambda x: x['name'], reverse=False)
         }
 
 class UserManager:

--- a/autopcr/module/accountmgr.py
+++ b/autopcr/module/accountmgr.py
@@ -275,7 +275,8 @@ class AccountManager:
         return self.secret.default_account
 
     def accounts(self) -> Iterator[str]:
-        for fn in os.listdir(self.root):
+        account_files = sorted(os.listdir(self.root))
+        for fn in account_files:
             if fn.endswith('.json'):
                 yield fn[:-5]
 
@@ -287,7 +288,7 @@ class AccountManager:
         return {
             'qq': self.qid,
             'default_account': self.default_account,
-            'accounts': sorted(accounts, key=lambda x: x['name'], reverse=False)
+            'accounts': accounts
         }
 
 class UserManager:

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -49,6 +49,7 @@ daily_modules = [
     hatsune_dear_reading,
     present_receive,
     smart_sweep,
+    last_quest_sweep,
     mirai_very_hard_sweep,
     smart_hard_sweep,
     smart_shiori_sweep,

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -49,10 +49,10 @@ daily_modules = [
     hatsune_dear_reading,
     present_receive,
     smart_sweep,
-    last_quest_sweep,
     mirai_very_hard_sweep,
     smart_hard_sweep,
     smart_shiori_sweep,
+    last_normal_quest_sweep,
     smart_normal_sweep,
 
     all_in_hatsune,

--- a/autopcr/module/modules/autosweep.py
+++ b/autopcr/module/modules/autosweep.py
@@ -84,6 +84,14 @@ class smart_normal_sweep(Module):
                     quest_id = sorted(quest_list, key = lambda x: quest_weight[x], reverse = True)
                     target_quest = await self.get_quests(quest_id, strategy, gap)
 
+                target_quest = list(set(target_quest).intersection(client.data.finishedQuest))
+                if len(target_quest) < 3:
+                    filtered_quests = [q for q in client.data.finishedQuest if q >= 11000000 and q < 12000000]
+                    if len(filtered_quests) > 10:
+                        target_quest = sorted(filtered_quests, reverse=True)[:10]
+                    else:
+                        target_quest = sorted(filtered_quests, reverse=True)
+
                 for target_id in target_quest:
                     try:
                         resp = await client.quest_skip_aware(target_id, 3)

--- a/autopcr/module/modules/autosweep.py
+++ b/autopcr/module/modules/autosweep.py
@@ -373,17 +373,16 @@ class smart_sweep(DIY_sweep):
         return quest
 
 @description('''
-循环刷取最新n图
+开新图时的便捷设置，将循环刷取所选关卡
 '''.strip())
-@name("刷新图")
-@conditional_execution1("last_quest_run_time", ['n庆典'])
-@inttype("last_sweep_quests_count", "刷取次数", 1, [i for i in range(41)])
-@multichoice("last_sweep_quests", '刷取关卡', [], db.last_normal_quest_candidate)
+@name("刷最新n图")
+@conditional_execution1("last_normal_quest_run_time", ['n庆典'])
+@multichoice("last_normal_quests_sweep", '刷取关卡', [], db.last_normal_quest_candidate)
 @default(False)
 @tag_stamina_consume
-class last_quest_sweep(DIY_sweep):
+class last_normal_quest_sweep(DIY_sweep):
     async def get_loop_quest(self, client: pcrclient) -> List[Tuple[int, int]]:
-        last_sweep_quests: List[str] = self.get_config('last_sweep_quests')
-        last_sweep_quests_count: int = int(self.get_config('last_sweep_quests_count'))
+        last_sweep_quests: List[str] = self.get_config('last_normal_quests_sweep')
+        last_sweep_quests_count: int = 3
         quest: List[Tuple[int, int]] = [(int(id.split(':')[0]), last_sweep_quests_count) for id in last_sweep_quests]
         return quest

--- a/autopcr/module/modules/sweep.py
+++ b/autopcr/module/modules/sweep.py
@@ -22,7 +22,7 @@ class explore_sweep(Module):
         if remain_cnt:
             quest_id = self.get_max_quest(client, sweep_available = True)
             if not quest_id:
-                raise AbortError("不存在可扫荡的探索")
+                raise SkipError("不存在可扫荡的探索")
             max_quest = self.get_max_quest(client)
             if self.not_max_stop() and max_quest != quest_id:
                 raise AbortError(f"最高级探索{max_quest}未通关，不扫荡\n如欲扫荡已通关的，请关闭【非最高不扫荡】")

--- a/autopcr/util/linq.py
+++ b/autopcr/util/linq.py
@@ -64,7 +64,7 @@ class flow(Iterator[T], Generic[T]):
 
     def max(self, func: Union[Callable[[T], Any], None] = None) -> T:
         if func is None:
-            return max(self.iterable)
+            return max(self.iterable, default=None)
         return max(self.iterable, key=func)
     
     def min(self, func: Union[Callable[[T], Any], None] = None) -> T:

--- a/autopcr/util/linq.py
+++ b/autopcr/util/linq.py
@@ -65,7 +65,7 @@ class flow(Iterator[T], Generic[T]):
     def max(self, func: Union[Callable[[T], Any], None] = None) -> T:
         if func is None:
             return max(self.iterable, default=None)
-        return max(self.iterable, key=func)
+        return max(self.iterable, key=func, default=None)
     
     def min(self, func: Union[Callable[[T], Any], None] = None) -> T:
         if func is None:


### PR DESCRIPTION
fix: empty sequence 添加default为空解决get_max_quest报错
fix: sort accounts 解决部分服务器上账户显示乱序
change: full stars 认为三星解锁，未满星关卡可以在游戏里直观显示，理论上并不需要这里提示
change: skip explore 探索全部未解锁属于非正常用途账户，考虑直接跳过提醒
add: filtered quests 如果智能刷图计算出的关卡全部未解锁，考虑刷取已解锁的最高关卡
