### PR TITLE
Feat/shiori-check

### DIFF
--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -658,6 +658,14 @@ class pcrclient(apiclient):
         req.target_viewer_id = user
         return await self.request(req)
 
+    async def shiori_mission_receive(self, event_id: int):
+        req = ShioriMissionAcceptRequest()
+        req.event_id = event_id
+        req.type = 2
+        req.id = 0
+        req.buy_id = 0
+        return await self.request(req)
+
     async def get_shiori_top(self):
         req = ShioriTopRequest()
         return await self.request(req)

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -819,6 +819,13 @@ class database():
                 3: '金',
                 4: '粉'
             }
+
+            self.shiori_event_quests: Dict[int, dict[int, ShioriQuest]] = (
+                ShioriQuest.query(db)
+                .group_by(lambda x: x.event_id)
+                .to_dict(lambda x: x.key, lambda x: x.to_dict(lambda x: x.quest_id, lambda x: x))
+            )
+
     def get_ex_equip_star_from_pt(self, id: int, pt: int) -> int:
         rarity = self.get_ex_equip_rarity(id)
         history_star = [star for star, enhancement_data in self.ex_equipment_enhance_data[rarity].items() if enhancement_data.total_point <= pt]

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -844,6 +844,21 @@ class SupportUnitChangeSettingResponse(responses.SupportUnitChangeSettingRespons
             for bonus in self.support_time_bonus:
                 mgr.update_inventory(bonus)
 
+@handles
+class ShioriMissionAcceptResponse(responses.ShioriMissionAcceptResponse):
+    async def update(self, mgr: datamgr, request):
+        if self.rewards:
+            for item in self.rewards:
+                mgr.update_inventory(item)
+
+        if self.team_level:
+            mgr.team_level = self.team_level
+
+        if self.stamina_info:
+            mgr.stamina = self.stamina_info.user_stamina
+            mgr.stamina_full_recovery_time = self.stamina_info.stamina_full_recovery_time
+
+
 # 菜 就别玩
 def custom_dict(self, *args, **kwargs):
     original_dict = super(TravelStartRequest, self).dict(*args, **kwargs)

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -9,6 +9,7 @@ from .daily import *
 from .gacha import *
 from .hatsune import *
 from .room import *
+from .shiori import *
 from .shop import *
 from .story import *
 from .sweep import *
@@ -101,6 +102,7 @@ daily_modules = ModuleList(
         
         clan_equip_request,
         love_up,
+        shiori_mission_check,
         main_story_reading,
         tower_story_reading,
         hatsune_story_reading,

--- a/autopcr/module/modules/shiori.py
+++ b/autopcr/module/modules/shiori.py
@@ -34,7 +34,7 @@ class shiori_mission_check(Module):
                 self.save_cache(f"shiori-check-{event_id}", 1)
                 continue
 
-            self._log(f"【{event_id} {db.event_name[event_id]}】")
+            self._log(f"{event_id}:{db.event_name[event_id]}：")
 
             if any(
                 m.mission_status == eMissionStatusType.EnableReceive

--- a/autopcr/module/modules/shiori.py
+++ b/autopcr/module/modules/shiori.py
@@ -51,3 +51,6 @@ class shiori_mission_check(Module):
                     self._warn(f"关卡 {db.quest_name[quest_id]} 尚未通关")
                 elif top_quests[quest_id].clear_flg != 3:
                     self._warn(f"关卡 {db.quest_name[quest_id]} 尚未取得3星")
+
+        if not self.log:
+            raise SkipError("所有已通关外传的任务奖励均已领取")

--- a/autopcr/module/modules/shiori.py
+++ b/autopcr/module/modules/shiori.py
@@ -1,0 +1,53 @@
+from ..modulebase import *
+from ..config import *
+from ...core.pcrclient import pcrclient
+from ...model.error import *
+from ...db.database import db
+from ...model.enums import *
+
+
+@description("领取已通关外传的任务奖励，对于未通关或未取得三星的关卡会进行提示")
+@name("领取外传任务奖励")
+@default(True)
+class shiori_mission_check(Module):
+    async def do_task(self, client: pcrclient):
+        shiori_top = await client.get_shiori_top()
+        clear_event_list = shiori_top.clear_event_list
+
+        if not clear_event_list:
+            raise SkipError("没有已通关的外传活动")
+
+        for event_id in clear_event_list:
+            if self.find_cache(f"shiori-check-{event_id}"):
+                continue
+
+            event_top = await client.get_shiori_event_top(event_id)
+            event_quests = db.shiori_event_quests[event_id]
+            top_quests = {q.quest_id: q for q in event_top.quest_list}
+
+            if all(
+                m.mission_status == eMissionStatusType.AlreadyReceive
+                for m in event_top.missions
+            ) and sum(q.clear_flg == 3 for q in event_top.quest_list) == len(
+                event_quests
+            ):
+                self.save_cache(f"shiori-check-{event_id}", 1)
+                continue
+
+            self._log(f"【{event_id} {db.event_name[event_id]}】")
+
+            if any(
+                m.mission_status == eMissionStatusType.EnableReceive
+                for m in event_top.missions
+            ):
+                resp = await client.shiori_mission_receive(event_id)
+                self._log(
+                    f"领取了任务奖励，获得了:\n"
+                    + await client.serlize_reward(resp.rewards)
+                )
+
+            for quest_id in event_quests:
+                if quest_id not in top_quests:
+                    self._warn(f"关卡 {db.quest_name[quest_id]} 尚未通关")
+                elif top_quests[quest_id].clear_flg != 3:
+                    self._warn(f"关卡 {db.quest_name[quest_id]} 尚未取得3星")


### PR DESCRIPTION
### 介绍
领取已通关的外传任务奖励并同时检查是否有未通关/未取得3星的活动关卡
![image](https://github.com/user-attachments/assets/2c71bf08-f921-4623-9313-dfea3a759b60)
![image](https://github.com/user-attachments/assets/c97991ef-26bb-41c5-a794-e1891204365d)

### 原因
外传只要打完3个难度的boss后当前外传就会显示已通关
任务奖励是否领完，关卡是否全3星看不出来，所以写了个这个

年前最后一个pr了应该是（
祝大伙新年快乐🎉