### PR TITLE
fix: check quest

### DIFF
--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -667,6 +667,8 @@ class pcrclient(apiclient):
         return await self.request(req)
 
     async def get_shiori_top(self):
+        if not self.data.is_quest_cleared(11003002):
+            raise SkipError("未解锁外传")
         req = ShioriTopRequest()
         return await self.request(req)
 


### PR DESCRIPTION
外传需要通关主线3-2后解锁，id `11003002`
![image](https://github.com/user-attachments/assets/10156ac9-a2ef-41ca-80aa-eb7a2ee633cd)
![image](https://github.com/user-attachments/assets/6e537490-f648-4610-9092-e6eadd2b3e18)
