### PR TITLE
系统是Windows时跳过time.tzset()

### DIFF
--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -1511,6 +1511,10 @@ class database():
 
 import os, time
 os.environ['TZ'] = 'Asia/Shanghai'
-time.tzset() 
+
+# 防止Windows不支持tzset()
+if hasattr(time, 'tzset'):
+    # On Unix systems, tzset() updates the local time settings
+    time.tzset()
 
 db = database()


### PR DESCRIPTION
Windows不支持time.tzset()