### PR TITLE
更好的对时间字符串的解析

### DIFF
--- a/autopcr/module/modules/cron.py
+++ b/autopcr/module/modules/cron.py
@@ -11,8 +11,8 @@ class CronModule(Module):
     async def is_cron_condition(self) -> bool: ...
 
     async def is_cron_time(self, nhour: int, nminute: int) -> bool:
-        time = self.get_cron_time()
-        hour, minute = time.split(":")
+        time_args = self.get_cron_time().split(":")
+        hour, minute = time_args[0], time_args[1]
         return nhour == int(hour) and nminute == int(minute)
 
     async def update_client(self, client: pcrclient):


### PR DESCRIPTION
有些浏览器返回的字符串格式为 HH:MM:SS，直接split可能会报错