### PR TITLE
feat(core): Account-specific DEVICE-ID

### DIFF
--- a/autopcr/constants.py
+++ b/autopcr/constants.py
@@ -1,5 +1,6 @@
 import os
 from distutils.util import strtobool
+import uuid
 import logging
 
 SERVER_PORT = int(os.getenv("AUTOPCR_SERVER_PORT", "13200"))
@@ -31,6 +32,8 @@ CLAN_BATTLE_FORBID_PATH = os.path.join(CONFIG_PATH, 'clan_battle_forbidden.txt')
 LOG_PATH = os.path.join(ROOT_DIR, 'log/')
 LOG_LEVEL = logging.INFO
 
+UUID_NAMESPACE = uuid.UUID("83a3e9e1-2690-4ff2-88bb-075ba6a6743c")
+
 # Headers
 DEFAULT_HEADERS = {
     'Accept-Encoding': 'gzip',
@@ -40,7 +43,6 @@ DEFAULT_HEADERS = {
     'BATTLE-LOGIC-VERSION': '4',
     'BUNDLE-VER': '',
     'DEVICE': '2',
-    'DEVICE-ID': '7b1703a5d9b394e24051d7a5d4818f17',
     'DEVICE-NAME': 'OPPO PCRT00',
     'EXCEL-VER': '1.0.0',
     'GRAPHICS-DEVICE-NAME': 'Adreno (TM) 640',
@@ -62,7 +64,6 @@ IOS_HEADERS = {
     'BATTLE-LOGIC-VERSION': '4',
     'BUNDLE-VER': '',
     'DEVICE': '1',
-    'DEVICE-ID': 'CB03A1AC-B27D-5E96-9422-CBF0F4D333D7',
     'DEVICE-NAME': 'iPad13,8',
     'EXCEL-VER': '1.0.0',
     'GRAPHICS-DEVICE-NAME': 'Apple M1',
@@ -93,7 +94,6 @@ def refresh_headers(version: str = None):
 
     DEFAULT_HEADERS['APP-VER'] = VERSION
     IOS_HEADERS['APP-VER'] = VERSION
-
 
 
 refresh_headers()

--- a/autopcr/core/sdkclient.py
+++ b/autopcr/core/sdkclient.py
@@ -1,9 +1,10 @@
+import hashlib, uuid
 from enum import Enum
 from typing import Tuple, Coroutine, Any, List, Callable
 from abc import abstractmethod
 from ..sdk.validator import remoteValidator
 from copy import deepcopy
-from ..constants import DEFAULT_HEADERS, IOS_HEADERS
+from ..constants import DEFAULT_HEADERS, IOS_HEADERS, UUID_NAMESPACE
 from ..util.logger import instance as logger
 
 class platform(Enum):
@@ -54,8 +55,10 @@ class sdkclient:
     def header(self):
         if self._account.type == platform.Android:
             headers = deepcopy(DEFAULT_HEADERS)
+            headers['DEVICE-ID'] = hashlib.md5(self.account.encode('utf-8')).hexdigest()
         elif self._account.type == platform.IOS:
             headers = deepcopy(IOS_HEADERS)
+            headers['DEVICE-ID'] = str(uuid.uuid5(UUID_NAMESPACE, self.account)).upper()
         else:
             raise ValueError(f"Invalid platform {self._account.type}")
 

--- a/autopcr/core/sessionmgr.py
+++ b/autopcr/core/sessionmgr.py
@@ -16,7 +16,7 @@ class sessionmgr(Component[apiclient]):
         self.auto_relogin = True
         self._sdkaccount = None
         self.session_expire_time = 0
-        self.id = hashlib.md5( self.sdk.account.encode('utf-8')).hexdigest()
+        self.id = hashlib.md5(self.sdk.account.encode('utf-8')).hexdigest()
         if not os.path.exists(self.cacheDir):
             os.makedirs(self.cacheDir)
 


### PR DESCRIPTION
将DEFAULT_HEADERS中的DEVICE-ID改为启动时随机生成，以避免大量部署实例使用固定ID导致被封DEVICE-ID。