### PR TITLE
Dev

### DIFF
--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -79,6 +79,19 @@ class pcrclient(apiclient):
         req.surplus_dish_list = surplus_dish_list
         return await self.request(req)
 
+    async def caravan_spots_choice(self, season_id: int, choice: int):
+        req = CaravanSpotsChoiceRequest()
+        req.season_id = season_id
+        req.choice = choice
+        return await self.request(req)
+
+    async def caravan_dice_reroll(self, season_id: int, current_count: int, roll_num: int):
+        req = CaravanDiceRerollRequest()
+        req.season_id = season_id
+        req.current_count = current_count
+        req.roll_num = roll_num
+        return await self.request(req)
+
     async def caravan_dice_roll(self, season_id: int, current_num: int, roll_num: int):
         req = CaravanDiceRollRequest()
         req.season_id = season_id
@@ -133,6 +146,18 @@ class pcrclient(apiclient):
         req.block_id = block_id
         req.gacha_type = gacha_type
         req.current_currency_num = current_currency_num
+        return await self.request(req)
+
+    async def caravan_minigame_bs_start(self, season_id: int):
+        req = CaravanMinigameCccBsStartRequest()
+        req.season_id = season_id
+        return await self.request(req)
+
+    async def caravan_minigame_bs_finish(self, season_id: int, play_id: int, items: Dict[int, int]):
+        req = CaravanMinigameCccBsFinishRequest()
+        req.season_id = season_id
+        req.play_id = play_id
+        req.object_list = [CccFinishItemCountInfo(ccc_object_id=item_id, count=count) for item_id, count in items.items()]
         return await self.request(req)
 
     async def caravan_minigame_start(self):

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -609,6 +609,11 @@ class pcrclient(apiclient):
         await self.story_check(story_id)
         return await self.story_view(story_id)
 
+    async def read_xac_story(self, sub_story_id: int):
+        req = SubStoryXacReadStoryRequest()
+        req.sub_story_id = sub_story_id
+        await self.request(req)
+
     async def read_asb_story(self, sub_story_id: int):
         req = SubStoryAsbReadStoryRequest()
         req.sub_story_id = sub_story_id

--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -1202,6 +1202,8 @@ class pcrclient(apiclient):
     async def quest_skip_aware(self, quest: int, times: int, recover: bool = False, is_total: bool = False):
         name = db.get_quest_name(quest)
         if db.is_hatsune_quest(quest):
+            if not quest in db.quest_to_event:
+                raise AbortError(f"任务{name}不存在")
             event = db.quest_to_event[quest].event_id
             if not quest in self.data.hatsune_quest_dict[event]:
                 raise AbortError(f"任务{name}未通关或不存在")

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -67,6 +67,14 @@ class database():
             )
 
     @lazy_property
+    def caravan_buddy(self) -> Dict[int, CaravanBuddy]:
+        with self.dbmgr.session() as db:
+            return (
+                CaravanBuddy.query(db)
+                .to_dict(lambda x: x.buddy_id, lambda x: x)
+            )
+
+    @lazy_property
     def caravan_dish(self) -> Dict[int, CaravanDish]:
         with self.dbmgr.session() as db:
             return (

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -1193,6 +1193,14 @@ class database():
             )
 
     @lazy_property
+    def xac_story_data(self) -> Dict[int, XacStoryDatum]:
+        with self.dbmgr.session() as db:
+            return (
+                XacStoryDatum.query(db)
+                .to_dict(lambda x: x.sub_story_id, lambda x: x)
+            )
+
+    @lazy_property
     def asb_story_data(self) -> Dict[int, AsbStoryDatum]:
         with self.dbmgr.session() as db:
             return (

--- a/autopcr/db/methods.py
+++ b/autopcr/db/methods.py
@@ -113,6 +113,14 @@ class CaravanEventEffect(models.CaravanEventEffect):
         return lasting_msg
 
 @method
+class CaravanBuddy(models.CaravanBuddy):
+    def get_effect_desc(self, lasting = True) -> str:
+        lasting_msg = f"持续{self.effect_turn}回合" if self.effect_turn > 0 else "一次性"
+        if not lasting:
+            lasting_msg = ""
+        return f"{self.description.format(self.effect_value_1, self.effect_value_2)} {lasting_msg}"
+
+@method
 class EnemyRewardDatum(models.EnemyRewardDatum):
     def get_rewards(self) -> Iterator[Reward]:
         yield Reward(self.reward_type_1, self.reward_id_1, self.reward_num_1, self.odds_1)

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -675,6 +675,13 @@ class SeasonPassMissionAcceptResponse(responses.SeasonPassMissionAcceptResponse)
                 mgr.update_inventory(reward)
 
 @handles
+class SubStoryXacReadStoryResponse(responses.SubStoryXacReadStoryResponse):
+    async def update(self, mgr: datamgr, request):
+        if self.reward_info:
+            for reward in self.reward_info:
+                mgr.update_inventory(reward)
+
+@handles
 class SubStoryAsbReadStoryResponse(responses.SubStoryAsbReadStoryResponse):
     async def update(self, mgr: datamgr, request):
         if self.reward_info:

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -74,6 +74,13 @@ class CaravanMinigameCccFinishResponse(responses.CaravanMinigameCccFinishRespons
                 mgr.update_inventory(item)
 
 @handles
+class CaravanMinigameCccBsFinishResponse(responses.CaravanMinigameCccBsFinishResponse):
+    async def update(self, mgr: datamgr, request):
+        if self.reward_list:
+            for item in self.reward_list:
+                mgr.update_inventory(item)
+
+@handles
 class CaravanDishUseResponse(responses.CaravanDishUseResponse):
     async def update(self, mgr: datamgr, request):
         if self.reward_list:
@@ -81,6 +88,20 @@ class CaravanDishUseResponse(responses.CaravanDishUseResponse):
                 mgr.update_inventory(item)
         if self.sub_reward_list:
             for item in self.sub_reward_list:
+                mgr.update_inventory(item)
+
+@handles
+class CaravanDiceRollResponse(responses.CaravanDiceRollResponse):
+    async def update(self, mgr: datamgr, request):
+        if self.buddy_reward_list:
+            for item in self.buddy_reward_list:
+                mgr.update_inventory(item)
+
+@handles
+class CaravanProgressTurnResponse(responses.CaravanProgressTurnResponse):
+    async def update(self, mgr: datamgr, request):
+        if self.buddy_reward_list:
+            for item in self.buddy_reward_list:
                 mgr.update_inventory(item)
 
 @handles

--- a/autopcr/module/modules/autosweep.py
+++ b/autopcr/module/modules/autosweep.py
@@ -288,6 +288,8 @@ unique_equip_2_pure_memory_id = [
         113301, # 水七七香
         117001, # 水娇
         117101, # 水姐姐
+        113401, # 水星
+        113601, # 水黑骑
 ]
 @conditional_execution1("very_hard_sweep_run_time", ["vh庆典"])
 @description('储备专二需求的150碎片，包括' + ','.join(db.get_unit_name(unit_id) for unit_id in unique_equip_2_pure_memory_id))

--- a/autopcr/util/substory.py
+++ b/autopcr/util/substory.py
@@ -35,6 +35,15 @@ def GetSubStoryReader(sub_story_data: EventSubStory, client: pcrclient) -> Union
         return constructor[sub_story_data.event_id](client)
     return None
 
+@EventId(10132)
+class xac_substory(SubStoryReader):
+
+    def title(self, sub_story_id: int) -> str:
+        return db.xac_story_data[sub_story_id].title
+
+    async def read(self, sub_story_id: int):
+        await self.client.read_xac_story(sub_story_id)
+
 @EventId(10130)
 class asb_substory(SubStoryReader):
 


### PR DESCRIPTION
- 【大富翁】适配第三季，新增【骰子保留】的选项
- 【全局配置】的氪体数判断改为当前庆典的氪体数最大值，不再为优先级判断
- 【专二纯净碎片储备】新增水星和水黑骑的刷取需求
- 【阅读活动子剧情】支持最新活动
- 修复【全刷活动普图】的15图错误问题
- 修复【领取礼物箱】的日志问题