### PR TITLE
feat: unit promote to max level when no exceed

### DIFF
--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -751,7 +751,7 @@ class unit_set_unique_equip_growth(UnitController):
         await self.set_unique_growth_unit()
 
 @description('支持全部角色，装备星级-1表示不穿装备，自动拉等级指当前等级不足以穿装备或提升技能等级，将会提升角色等级，自动拉品级指当前品级不足以装备专武时，会提升角色品级，自动专武1指开专武2未开专武1时自动开专武1，使用原矿指装备不足时用原矿补充'
-             '\n等级升至上限：在当前升级条件下，升级至角色的允许等级上限（比如未突破角色升级至突破后等级，开启该选项可以避免升级至最大的未突破等级）')
+             '\n等级升至上限：在当前升级条件下，升级至角色允许的等级上限（比如未突破角色升级至突破后等级，开启该选项可以升级至最大的未突破等级，避免升级失败）')
 @name('拉角色练度')
 @booltype("unit_promote_to_max_level", "等级升至上限", False)
 @booltype("unit_promote_unique2_when_fail_to_unique_equip2", "自动专武1", False)

--- a/autopcr/module/modules/unit.py
+++ b/autopcr/module/modules/unit.py
@@ -751,9 +751,9 @@ class unit_set_unique_equip_growth(UnitController):
         await self.set_unique_growth_unit()
 
 @description('支持全部角色，装备星级-1表示不穿装备，自动拉等级指当前等级不足以穿装备或提升技能等级，将会提升角色等级，自动拉品级指当前品级不足以装备专武时，会提升角色品级，自动专武1指开专武2未开专武1时自动开专武1，使用原矿指装备不足时用原矿补充'
-             '\n未突破角色升级至最高允许的等级：未突破角色升级至突破等级（+10）时，将升级至角色的最高允许等级')
+             '\n等级升至上限：在当前升级条件下，升级至角色的允许等级上限（比如未突破角色升级至突破后等级，开启该选项可以避免升级至最大的未突破等级）')
 @name('拉角色练度')
-@booltype("unit_promote_to_max_level_when_no_exceed", "未突破角色升级至最高允许的等级", False)
+@booltype("unit_promote_to_max_level", "等级升至上限", False)
 @booltype("unit_promote_unique2_when_fail_to_unique_equip2", "自动专武1", False)
 @booltype("unit_promote_rank_when_fail_to_unique_equip", "自动拉品级", False)
 @booltype("unit_promote_level_when_fail_to_equip_or_skill", "自动拉等级", False)
@@ -784,7 +784,7 @@ class unit_promote(UnitController):
         self.auto_rank_up = bool(self.get_config('unit_promote_rank_when_fail_to_unique_equip'))
         self.use_raw_ore = bool(self.get_config('unit_promote_rank_use_raw_ore'))
         self.auto_unique1_slot = bool(self.get_config('unit_promote_unique2_when_fail_to_unique_equip2'))
-        self.to_max_level = bool(self.get_config('unit_promote_to_max_level_when_no_exceed'))
+        self.to_max_level = bool(self.get_config('unit_promote_to_max_level'))
 
         target_level = int(self.get_config('unit_promote_level'))
         target_promotion_rank = int(self.get_config('unit_promote_rank'))


### PR DESCRIPTION
## 现在的功能：
当升级等级设置为+10的等级时（比如现在队伍等级295，批量升级设置为305），未突破的角色会直接升级失败
<img width="503" height="389" alt="image" src="https://github.com/user-attachments/assets/3f4121a0-bce1-4387-ac9f-febbf0ca3177" />

## 修改后：
加入一个可选的开关，将允许未突破角色升级至最高允许的等级
<img width="701" height="172" alt="image" src="https://github.com/user-attachments/assets/063b3be7-2077-473a-8b39-b157471da8bc" />
<img width="421" height="284" alt="image" src="https://github.com/user-attachments/assets/1623f53a-1db4-4b7a-897a-f47d7d02f01a" />
<img width="773" height="642" alt="image" src="https://github.com/user-attachments/assets/e208bbf5-9e6d-45be-a822-e2e83dda2285" />
