### PR TITLE
fix: ensure db and manifest directories exist before file operations

### DIFF
--- a/autopcr/db/assetmgr.py
+++ b/autopcr/db/assetmgr.py
@@ -69,6 +69,7 @@ class assetmgr:
     async def init(self, ver):
         self.registries.clear()
 
+        os.makedirs(os.path.join(CACHE_DIR, 'manifest'), exist_ok=True)
         cacheFile = os.path.join(CACHE_DIR, 'manifest', f'{ver}.json')
         try:
             self.root = content.parse_file(cacheFile)

--- a/autopcr/db/dbstart.py
+++ b/autopcr/db/dbstart.py
@@ -20,7 +20,8 @@ async def do_update_database() -> int:
     version = (await rsp.json())['TruthVersion']
 
     url = f'https://redive.estertion.win/db/redive_cn.db.br'
-    
+
+    os.makedirs(os.path.join(CACHE_DIR, 'db'), exist_ok=True)
     save_path = os.path.join(CACHE_DIR, "db", f"{version}.db")
     try:
         rsp = await aiorequests.get(url, headers={'Accept-Encoding': 'br'}, stream=True, timeout=20)


### PR DESCRIPTION
- Added directory creation with `os.makedirs()` for db and manifest
- Used `exist_ok=True` to safely create directories only when missing
- Prevented FileNotFoundError by ensuring parent directories exist
- fix #235 