### PR TITLE
fix: talent sweep

### DIFF
--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -63,8 +63,8 @@ class datamgr(BaseModel, Component[apiclient]):
     version: int = 1
     caravan_dishes: typing.Counter[int] = Counter()
     user_clan_battle_ex_equip_restriction: Dict[int, RestrictionExtraEquip] = {}
-    talent_quest_area_info: dict[int, TalentQuestAreaInfo] = {}
-    cleared_talent_quest_id_set: set[int] = set()
+    talent_quest_area_info: Dict[int, TalentQuestAreaInfo] = {}
+    cleared_talent_quest_id_set: Set[int] = set()
 
     @staticmethod
     async def try_update_database(ver: int):

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -490,13 +490,11 @@ class HomeIndexResponse(responses.HomeIndexResponse):
         shiori_dict = {q.quest_id: q for q in self.shiori_quest_info.quest_list} if self.shiori_quest_info and self.shiori_quest_info.quest_list else {}
         mgr.quest_dict.update(shiori_dict)
 
-        if self.talent_quest_area_info:
-            mgr.talent_quest_area_info = {
-                v.talent_id: v for v in self.talent_quest_area_info
-            }
+        mgr.talent_quest_area_info = {
+            v.talent_id: v for v in self.talent_quest_area_info
+        }
 
-        if self.cleared_talent_quest_id_list:
-            mgr.cleared_talent_quest_id_set |= set(self.cleared_talent_quest_id_list)
+        mgr.cleared_talent_quest_id_set = set(self.cleared_talent_quest_id_list)
 
         mgr.ready = True
 

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -10,10 +10,10 @@ from ...model.enums import *
 from ...model.custom import ItemType
 from ...util.linq import flow
 
-from typing import cast
+from typing import List, Dict, Tuple
 
-TALENT_TARGET_NAMES: list[str] = list(db.talents.keys())
-TALENT_QUESTS: dict[str, list[tuple[str, int]]] = {
+TALENT_TARGET_NAMES: List[str] = list(db.talents.keys())
+TALENT_QUESTS: Dict[str, List[Tuple[str, int]]] = {
     t_name: [
         (q.quest_name, q.quest_id)
         for q in db.talent_quests_by_area[db.talent_areas[t.talent_id].area_id].values()
@@ -58,10 +58,10 @@ class talent_sweep(Module):
 
     async def do_task(self, client: pcrclient):
         targets = self.get_config("talent_sweep_targets")
-        target_recovery_areas: list[str] = self.get_config(
+        target_recovery_areas: List[str] = self.get_config(
             "talent_sweep_target_recovery_areas"
         )
-        quest_threshold: dict[str, str] = {
+        quest_threshold: Dict[str, str] = {
             t_name: self.get_config(f"talent_sweep_quest_threshold_{t.talent_id}")
             for t_name, t in db.talents.items()
         }
@@ -122,7 +122,7 @@ class talent_sweep(Module):
                 )
                 continue
 
-            res: list[InventoryInfo] = []
+            res: List[InventoryInfo] = []
             sweep_cnt = 0
             recovery_cnt = 0
             while self.get_daily_clear_count(client, talent_id) < total_times:

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -153,6 +153,8 @@ class talent_sweep(Module):
                 res.extend(r.bonus_reward_list)
             if sweep_cnt > 0:
                 self._log(
-                    f"> 扫荡[{db.quest_name[max_quest_id]}]共{sweep_cnt}次，重置{recovery_cnt}次，获得："
-                    "\n" + await client.serialize_reward_summary(res)
+                    f"> 扫荡[{db.quest_name[max_quest_id]}]共{sweep_cnt}次，"
+                    + (f"重置{recovery_cnt}次，" if recovery_cnt > 0 else "")
+                    + "获得：\n"
+                    + await client.serialize_reward_summary(res)
                 )


### PR DESCRIPTION
修复2个小问题：
1. 日常刷新后当天如果没有通关过深域，home index返回的talent area info会是一个空对象，datamgr不会更新
2. python旧版本type hint兼容