### PR TITLE
fix: talent sweep

### DIFF
--- a/autopcr/core/pcrclient.py
+++ b/autopcr/core/pcrclient.py
@@ -1270,10 +1270,6 @@ class pcrclient(apiclient):
                 result.append(
                     f"未知物品({value[2], type},{value[2].id})x{value[0]}({value[1]})"
                 )
-        if target is not None and len(result) == 0:
-            result.append(
-                f"{db.get_inventory_name_san(target)}x0({self.data.get_inventory(target)})"
-            )
         return "\n".join(result) if result else "无"
 
     async def serialize_unit_info(self, unit_data: Union[UnitData, UnitDataLight]) -> Tuple[bool, str]:

--- a/autopcr/model/handlers.py
+++ b/autopcr/model/handlers.py
@@ -490,11 +490,12 @@ class HomeIndexResponse(responses.HomeIndexResponse):
         shiori_dict = {q.quest_id: q for q in self.shiori_quest_info.quest_list} if self.shiori_quest_info and self.shiori_quest_info.quest_list else {}
         mgr.quest_dict.update(shiori_dict)
 
-        mgr.talent_quest_area_info = {
-            v.talent_id: v for v in self.talent_quest_area_info
-        }
-
-        mgr.cleared_talent_quest_id_set = set(self.cleared_talent_quest_id_list)
+        if self.talent_quest_area_info is not None:
+            mgr.talent_quest_area_info = {
+                v.talent_id: v for v in self.talent_quest_area_info
+            }
+        if self.cleared_talent_quest_id_list is not None:
+            mgr.cleared_talent_quest_id_set = set(self.cleared_talent_quest_id_list)
 
         mgr.ready = True
 

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -156,5 +156,9 @@ class talent_sweep(Module):
                     f"> 扫荡[{db.quest_name[max_quest_id]}]共{sweep_cnt}次，"
                     + (f"重置{recovery_cnt}次，" if recovery_cnt > 0 else "")
                     + "获得：\n"
-                    + await client.serialize_reward_summary(res)
+                    + await client.serialize_reward_summary(
+                        res,
+                        item_filter=lambda _, name: "星幽" in name,
+                        ignore_summary=True,
+                    )
                 )

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -156,9 +156,7 @@ class talent_sweep(Module):
                     f"> 扫荡[{db.quest_name[max_quest_id]}]共{sweep_cnt}次，"
                     + (f"重置{recovery_cnt}次，" if recovery_cnt > 0 else "")
                     + "获得：\n"
-                    + await client.serialize_reward_summary(
-                        res,
-                        item_filter=lambda _, name: "星幽" in name,
-                        ignore_summary=True,
+                    + await client.serlize_reward(
+                        res, item_filter=lambda _, name: "星幽" in name
                     )
                 )


### PR DESCRIPTION
1. 修复home index中talent相关字段为None/`{}`的情况，其中`{}`表示今天还没有进行过深域战斗活动，是一个有意义的值
2. 奖励序列化的时候加入了一个filter和ignore，可以忽略掉summary内容，以及根据item和name对物品进行filter，下方是前后对比：
<img width="943" height="658" alt="image" src="https://github.com/user-attachments/assets/8f7c61d4-c3ad-4b3d-bf7f-3c6814f91e87" />
<img width="463" height="276" alt="image" src="https://github.com/user-attachments/assets/a4dd2a63-6e11-451d-85a4-606d1cc00862" />
