### PR TITLE
bugfix: 角色单选列表不会随数据库更新而更新

### DIFF
--- a/autopcr/module/config.py
+++ b/autopcr/module/config.py
@@ -258,7 +258,7 @@ class UnitConfigMixin:
 
 class UnitChoiceConfig(UnitConfigMixin, SingleChoiceConfig):
     def __init__(self, key: str, desc: str):
-        super().__init__(key, desc, 100101, db.unlock_unit_condition)
+        super().__init__(key, desc, 100101, db.unlock_unit_condition_candidate)
 
     def process_value(self, value):
         if isinstance(value, str) and ':' in value: # Compatible with the old version


### PR DESCRIPTION
UnitChoiceConfig 原来传 db.unlock_unit_condition（初始化时立即求值，拿到固定 dict）， 改为传 db.unlock_unit_condition_candidate
（方法引用，每次访问 candidates 时重新调用，走 lazy_property 的版本检查逻辑）， 与 UnitListConfig 保持一致。