### PR TITLE
feat: 禅模式支持会战午后

### DIFF
--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -2123,12 +2123,15 @@ class database():
                 .select(lambda x: (db.parse_time(x.start_time), db.parse_time(x.end_time)))
                 .to_list()
              )
+        is_afternoon = now >= self.get_start_time(now) + half_day
         campaign_list = {
             "n3以上前夕": lambda: not self.is_target_time(n3, now) and self.is_target_time(n3, tomorrow),
             "n3以上首日午前": lambda: self.is_target_time(n3, now) and not self.is_target_time(n3, now - half_day),
             "h3以上前夕": lambda: not self.is_target_time(h3, now) and self.is_target_time(h3, tomorrow),
             "会战前夕": lambda: not self.is_clan_battle_time(now) and self.is_clan_battle_time(tomorrow),
+            "会战前夕午后": lambda: not self.is_clan_battle_time(now) and self.is_clan_battle_time(tomorrow) and is_afternoon,
             "会战期间": lambda: self.is_clan_battle_time(now),
+            "会战期间午后": lambda: self.is_clan_battle_time(now) and is_afternoon,
             "总是执行": lambda: True,
         }
         if campaign not in campaign_list:

--- a/autopcr/module/config.py
+++ b/autopcr/module/config.py
@@ -353,7 +353,7 @@ class ConditionalExecution1Config(ConditionalExecutionClient, MultiChoiceConfig)
 
 class ConditionalExecution2Config(ConditionalExecutionDB, MultiChoiceConfig):
     def __init__(self, key: str, desc: str = "执行条件", default=[], check: bool = True):
-        super().__init__(key, desc, default, ['n3以上前夕', 'n3以上首日午前', 'h3以上前夕', '会战前夕', '会战期间', '总是执行'], check)
+        super().__init__(key, desc, default, ['n3以上前夕', 'n3以上首日午前', 'h3以上前夕', '会战前夕午后', '会战前夕', '会战期间午后', '会战期间', '总是执行'], check)
 
 class ConditionalExecution3Config(ConditionalExecutionClient, MultiChoiceConfig):
     def __init__(self, key: str, desc: str = "执行条件", default=[], check: bool = True):


### PR DESCRIPTION
禅模式添加“会战前夕午后”和“会战期间午后”。
支持会战前一天早上正常领取/消耗体力、会战早起出刀时正常领取/消耗体力来攒 CP。
对于早上能上线的玩家比较友好，不需要上号再刷体力了。
晚上还是依然自己管理，可以选择好留部分体力供早上刷取。
已经于3月会战测试。