### PR TITLE
基本信息显示优化+Python 3.8 兼容

### DIFF
--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -605,6 +605,8 @@ class datamgr(BaseModel, Component[apiclient]):
             return self.get_inventory((eInventoryType.Item, 90010))
         elif shop_id == eSystemId.EX_EQUIPMENT_ACCESSORY_SHOP: # EX饰品店
             return self.get_inventory((eInventoryType.Item, 90011))
+        elif shop_id == eSystemId.CONNECT_SHOP: # 连结商店
+            return self.get_inventory((eInventoryType.Item, 90012))
         else:
             raise ValueError(f"未知的商店{shop_id}")
 

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -69,6 +69,7 @@ class database():
     sun_ball: ItemType = (eInventoryType.Item, 25014)
     dark_ball: ItemType = (eInventoryType.Item, 25015)
     ex_rainbow_enhance_pt: ItemType = (eInventoryType.Item, 26202)
+    ex_rainbow_enhance_ball: ItemType = (eInventoryType.Item, 26203)
 
     def __init__(self):
         self.dbmgr: Optional[dbmgr] = None

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -384,7 +384,7 @@ class user_info(Module):
 
         if '玛娜' in display_items:
             mana = client.data.gold.gold_id_free + client.data.gold.gold_id_pay
-            optional_info['玛娜'] = format_number(mana, scale='亿', decimals=1, seperator='no')
+            optional_info['玛娜'] = format_number(mana, scale='亿', decimals=1, separator='no')
 
         if '心碎' in display_items:
             heart = client.data.get_inventory(db.heart)
@@ -420,7 +420,7 @@ class user_info(Module):
 
         if '炼金点数' in display_items:
             alces_pt = client.data.get_inventory(db.ex_rainbow_enhance_pt)
-            optional_info['炼金点数'] = format_number(alces_pt, scale='万', decimals=0, seperator='no')
+            optional_info['炼金点数'] = format_number(alces_pt, scale='万', decimals=0, separator='no')
 
         if '香水' in display_items:
             perfume = client.data.get_inventory((eInventoryType.Item, 26203))
@@ -436,7 +436,7 @@ class user_info(Module):
 
         if '大师币' in display_items:
             master_coin = client.data.get_inventory((eInventoryType.Item, 90008))
-            optional_info['大师币'] = format_number(master_coin, scale='万', decimals=1, seperator='no')
+            optional_info['大师币'] = format_number(master_coin, scale='万', decimals=1, separator='no')
 
         if '连结币' in display_items:
             link_coin = client.data.get_inventory((eInventoryType.Item, 99007))
@@ -447,7 +447,7 @@ class user_info(Module):
         #     ex_weapon = client.data.get_inventory((eInventoryType.Item, 90009))
         #     ex_armor = client.data.get_inventory((eInventoryType.Item, 90010))
         #     ex_accessory = client.data.get_inventory((eInventoryType.Item, 90011))
-        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, seperator='no')
+        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, separator='no')
         #     optional_info['EX装备币'] = f"{fmt_coin(ex_weapon)}/{fmt_coin(ex_armor)}/{fmt_coin(ex_accessory)}"
 
         # if '商店币' in display_items:
@@ -455,7 +455,7 @@ class user_info(Module):
         #     arena_coin = client.data.get_inventory((eInventoryType.Item, 90003))
         #     grand_arena_coin = client.data.get_inventory((eInventoryType.Item, 90004))
         #     clan_coin = client.data.get_inventory((eInventoryType.Item, 90006))
-        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, seperator='no')
+        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, separator='no')
         #     optional_info['商店币'] = f"{fmt_coin(dungeon_coin)}/{fmt_coin(arena_coin)}/{fmt_coin(grand_arena_coin)}/{fmt_coin(clan_coin)}"
 
         # if '原矿' in display_items:
@@ -471,21 +471,21 @@ class user_info(Module):
         #     exp_potions = [client.data.get_inventory((eInventoryType.Item, item_id))
         #                    for item_id in range(20004, 20000, -1)]
         #     optional_info['经验药剂'] = '/'.join(
-        #         format_number(cnt, scale='万', decimals=2, seperator='auto') for cnt in exp_potions)
+        #         format_number(cnt, scale='万', decimals=2, separator='auto') for cnt in exp_potions)
 
         # if '精炼石' in display_items:
         #     # 精炼石 ID: 22001-22006，按ID倒序
         #     refine_stones = [client.data.get_inventory((eInventoryType.Item, item_id))
         #                      for item_id in range(22006, 22000, -1)]
         #     optional_info['精炼石'] = '/'.join(
-        #         format_number(cnt, scale='万', decimals=2, seperator='auto') for cnt in refine_stones)
+        #         format_number(cnt, scale='万', decimals=2, separator='auto') for cnt in refine_stones)
 
         # if '好感礼物' in display_items:
         #     # 蛋糕类 ID: 50001-50003，按ID倒序
         #     cakes = [client.data.get_inventory((eInventoryType.Item, item_id))
         #              for item_id in range(50003, 50000, -1)]
         #     optional_info['好感礼物'] = '/'.join(
-        #         format_number(cnt, scale='万', decimals=2, seperator='auto') for cnt in cakes)
+        #         format_number(cnt, scale='万', decimals=2, separator='auto') for cnt in cakes)
 
         # 输出格式
         if stamina >= max_stamina:

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -1,4 +1,5 @@
-from typing import List
+from decimal import ROUND_HALF_UP, Decimal
+from typing import List, Literal, Optional, Tuple
 
 from ...model.common import InventoryInfo
 from ..modulebase import *
@@ -279,27 +280,240 @@ class jjc_reward(Module):
             await client.receive_grand_arena_reward()
         self._log(f"pjjc币x{info.reward_info.count}")
 
-@description('展示基本信息')
+_USER_INFO_DISPLAY_ORDER = (
+    '玛娜', '心碎', '星杯', '星幽碎片', '属性球', '大师碎片', '炼金点数',
+    '香水', '扫荡券', '加速券', '大师币', '连结币',
+)
+
+_CN_SCALE: Tuple[Tuple[str, int], ...] = (('亿', 10 ** 8), ('万', 10 ** 4))
+_EN_SCALE: Tuple[Tuple[str, int], ...] = (('b', 10 ** 9), ('m', 10 ** 6), ('k', 10 ** 3))
+
+
+def _resolve_scale_unit(val: int, scale: Literal['k', 'm', 'b', '万', '亿']) -> Tuple[int, str]:
+    ladder = _CN_SCALE if scale in ('万', '亿') else _EN_SCALE
+    start = next(i for i, (s, _) in enumerate(ladder) if s == scale)
+    av = abs(val)
+    for i in range(start, len(ladder)):
+        suf, div = ladder[i]
+        if av >= div:
+            return div, suf
+    return 1, ''
+
+
+def _round_scaled_quotient(quotient: Decimal, decimals: int) -> str:
+    if decimals <= 0:
+        n = quotient.quantize(Decimal('1'), rounding=ROUND_HALF_UP)
+        return str(int(n))
+    step = Decimal('1').scaleb(-decimals)
+    n = quotient.quantize(step, rounding=ROUND_HALF_UP)
+    s = format(n, 'f')
+    if '.' in s:
+        s = s.rstrip('0').rstrip('.')
+    return s
+
+
+def _group_int_string(int_part: str, use_grouping: bool) -> str:
+    if not use_grouping or not int_part:
+        return int_part
+    sign = ''
+    if int_part[0] == '-':
+        sign = '-'
+        int_part = int_part[1:]
+    elif int_part[0] == '+':
+        sign = '+'
+        int_part = int_part[1:]
+    rev = int_part[::-1]
+    pieces = [rev[i:i + 3][::-1] for i in range(0, len(rev), 3)]
+    return sign + ','.join(reversed(pieces))
+
+
+def _apply_numeric_separator(num_str: str, mode: Literal['auto', 'no', 'yes'], original_val: int) -> str:
+    if mode == 'no':
+        use = False
+    elif mode == 'yes':
+        use = True
+    else:
+        use = abs(original_val) >= 100_000
+    if '.' in num_str:
+        a, b = num_str.split('.', 1)
+        return _group_int_string(a, use) + '.' + b
+    return _group_int_string(num_str, use)
+
+
+def format_number(
+    val: int,
+    scale: Optional[Literal['k', 'm', 'b', '万', '亿']] = None,
+    decimals: Optional[int] = None,
+    seperator: Literal['auto', 'no', 'yes'] = 'auto',
+) -> str:
+    if scale is None:
+        s = str(int(val))
+        return _apply_numeric_separator(s, seperator, val)
+    dec = 2 if decimals is None else decimals
+    div, suffix = _resolve_scale_unit(val, scale)
+    if not suffix:
+        s = str(int(val))
+        return _apply_numeric_separator(s, seperator, val)
+    q = Decimal(val) / Decimal(div)
+    coeff = _round_scaled_quotient(q, dec)
+    return _apply_numeric_separator(coeff, seperator, val) + suffix
+
+
+@description('展示基本信息，固定显示玩家名、体力、等级、钻石、母猪石、全角色战力，可自定义显示其他信息')
 @name('基本信息')
 @default(True)
+@multichoice("user_info_display", "显示信息",
+    ['玛娜', '心碎', '星幽碎片', '炼金点数'],
+    ['玛娜', '心碎', '星杯', '星幽碎片', '属性球', '大师碎片', '炼金点数', '香水', '扫荡券', '加速券', '大师币', '连结币'])
 class user_info(Module):
     async def do_task(self, client: pcrclient):
         now = db.format_time(apiclient.datetime)
+        display_items = set(self.get_config('user_info_display'))
+
+        # 固定信息
         name = client.data.user_name
         level = client.data.team_level
         stamina = client.data.stamina
         max_stamina = db.team_info[client.data.team_level].max_stamina
-        jewel = client.data.jewel.free_jewel
-        mana = client.data.gold.gold_id_free
-        sweep_ticket = client.data.get_inventory((eInventoryType.Item, 23001))
+        jewel = client.data.jewel.free_jewel + client.data.jewel.jewel
         pig = client.data.get_inventory((eInventoryType.Item, 90005))
         tot_power = sum([client.data.get_unit_power(unit) for unit in client.data.unit])
 
+        # 可选信息
+        optional_info = {}
+
+        if '玛娜' in display_items:
+            mana = client.data.gold.gold_id_free + client.data.gold.gold_id_pay
+            optional_info['玛娜'] = format_number(mana, scale='亿', decimals=1, seperator='no')
+
+        if '心碎' in display_items:
+            heart = client.data.get_inventory(db.heart)
+            xinsui = client.data.get_inventory(db.xinsui)
+            if heart > 0:
+                optional_info['心碎'] = f"{format_number(xinsui)}(大心 {format_number(heart)})"
+            else:
+                optional_info['心碎'] = format_number(xinsui)
+
+        if '星杯' in display_items:
+            star_cup = client.data.get_inventory(db.xingqiubei)
+            optional_info['星杯'] = format_number(star_cup)
+
+        if '星幽碎片' in display_items:
+            xinyou = client.data.get_inventory(db.xinyou)
+            optional_info['星幽碎片'] = format_number(xinyou)
+
+        if '属性球' in display_items:
+            fire = client.data.get_inventory(db.fire_ball)
+            water = client.data.get_inventory(db.water_ball)
+            wind = client.data.get_inventory(db.wind_ball)
+            sun = client.data.get_inventory(db.sun_ball)
+            dark = client.data.get_inventory(db.dark_ball)
+            optional_info['属性球'] = f"{format_number(fire)}/{format_number(water)}/{format_number(wind)}/{format_number(sun)}/{format_number(dark)}"
+
+        if '大师碎片' in display_items:
+            master = client.data.get_inventory(db.master_fragment)
+            master_f = client.data.get_inventory(db.master_ffragment)
+            if master_f > 0:
+                optional_info['大师碎片'] = f"{master}(残片 {master_f})"
+            else:
+                optional_info['大师碎片'] = str(master)
+
+        if '炼金点数' in display_items:
+            alces_pt = client.data.get_inventory(db.ex_rainbow_enhance_pt)
+            optional_info['炼金点数'] = format_number(alces_pt, scale='万', decimals=0, seperator='no')
+
+        if '香水' in display_items:
+            perfume = client.data.get_inventory((eInventoryType.Item, 26203))
+            optional_info['香水'] = str(perfume)
+
+        if '扫荡券' in display_items:
+            sweep_ticket = client.data.get_inventory((eInventoryType.Item, 23001))
+            optional_info['扫荡券'] = format_number(sweep_ticket)
+
+        if '加速券' in display_items:
+            speed_ticket = client.data.get_inventory(db.travel_speed_up_paper)
+            optional_info['加速券'] = str(speed_ticket)
+
+        if '大师币' in display_items:
+            master_coin = client.data.get_inventory((eInventoryType.Item, 90008))
+            optional_info['大师币'] = format_number(master_coin, scale='万', decimals=1, seperator='no')
+
+        if '连结币' in display_items:
+            link_coin = client.data.get_inventory((eInventoryType.Item, 99007))
+            optional_info['连结币'] = str(link_coin)
+
+        # 注释掉的琐碎物品（方便后续启用）
+        # if 'EX装备币' in display_items:
+        #     ex_weapon = client.data.get_inventory((eInventoryType.Item, 90009))
+        #     ex_armor = client.data.get_inventory((eInventoryType.Item, 90010))
+        #     ex_accessory = client.data.get_inventory((eInventoryType.Item, 90011))
+        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, seperator='no')
+        #     optional_info['EX装备币'] = f"{fmt_coin(ex_weapon)}/{fmt_coin(ex_armor)}/{fmt_coin(ex_accessory)}"
+
+        # if '商店币' in display_items:
+        #     dungeon_coin = client.data.get_inventory((eInventoryType.Item, 90002))
+        #     arena_coin = client.data.get_inventory((eInventoryType.Item, 90003))
+        #     grand_arena_coin = client.data.get_inventory((eInventoryType.Item, 90004))
+        #     clan_coin = client.data.get_inventory((eInventoryType.Item, 90006))
+        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, seperator='no')
+        #     optional_info['商店币'] = f"{fmt_coin(dungeon_coin)}/{fmt_coin(arena_coin)}/{fmt_coin(grand_arena_coin)}/{fmt_coin(clan_coin)}"
+
+        # if '原矿' in display_items:
+        #     # 原矿 ID 范围通常是 35000-35999，按ID倒序
+        #     ores = [(item_id, client.data.get_inventory((eInventoryType.Item, item_id)))
+        #             for item_id in range(35999, 34999, -1)
+        #             if client.data.get_inventory((eInventoryType.Item, item_id)) > 0]
+        #     if ores:
+        #         optional_info['原矿'] = '/'.join(str(cnt) for _, cnt in ores)
+
+        # if '经验药剂' in display_items:
+        #     # 经验药剂 ID: 20001-20004，按ID倒序
+        #     exp_potions = [client.data.get_inventory((eInventoryType.Item, item_id))
+        #                    for item_id in range(20004, 20000, -1)]
+        #     optional_info['经验药剂'] = '/'.join(
+        #         format_number(cnt, scale='万', decimals=2, seperator='auto') for cnt in exp_potions)
+
+        # if '精炼石' in display_items:
+        #     # 精炼石 ID: 22001-22006，按ID倒序
+        #     refine_stones = [client.data.get_inventory((eInventoryType.Item, item_id))
+        #                      for item_id in range(22006, 22000, -1)]
+        #     optional_info['精炼石'] = '/'.join(
+        #         format_number(cnt, scale='万', decimals=2, seperator='auto') for cnt in refine_stones)
+
+        # if '好感礼物' in display_items:
+        #     # 蛋糕类 ID: 50001-50003，按ID倒序
+        #     cakes = [client.data.get_inventory((eInventoryType.Item, item_id))
+        #              for item_id in range(50003, 50000, -1)]
+        #     optional_info['好感礼物'] = '/'.join(
+        #         format_number(cnt, scale='万', decimals=2, seperator='auto') for cnt in cakes)
+
+        # 输出格式
         if stamina >= max_stamina:
             self._warn(f"体力爆了！")
-        self._log(f"{name} 体力{stamina}({max_stamina}) 等级{level} 钻石{jewel}")
-        self._log(f"玛那{mana} 扫荡券{sweep_ticket} 母猪石{pig}")
-        self._log(f"全角色战力：{tot_power}")
+
+        # 第一行：固定信息
+        self._log(f"{name} 体力{stamina}({max_stamina}) 等级{level} 钻石{format_number(jewel)}")
+
+        # 第二行：可选信息（前两项）+ 母猪石（顺序与配置候选项一致，避免 set 迭代无序）
+        line2_items = []
+        keys = [k for k in _USER_INFO_DISPLAY_ORDER if k in optional_info]
+        for i in range(min(2, len(keys))):
+            line2_items.append(f"{keys[i]}{optional_info[keys[i]]}")
+        line2_items.append(f"母猪石{format_number(pig)}")
+        self._log(' '.join(line2_items))
+
+        # 第三行及以后：每行3个属性
+        remaining_keys = keys[2:]
+        for i in range(0, len(remaining_keys), 3):
+            line_items = []
+            for j in range(3):
+                if i + j < len(remaining_keys):
+                    key = remaining_keys[i + j]
+                    line_items.append(f"{key}{optional_info[key]}")
+            self._log(' '.join(line_items))
+
+        # 最后一行：全角色战力
+        self._log(f"全角色战力：{format_number(tot_power)}")
         self._log(f"已氪体数：{client.data.recover_stamina_exec_count}")
         self._log(f"清日常时间：{now}")
 

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -1,5 +1,4 @@
-from decimal import ROUND_HALF_UP, Decimal
-from typing import List, Literal, Optional, Tuple
+from typing import List
 
 from ...model.common import InventoryInfo
 from ..modulebase import *
@@ -10,6 +9,7 @@ from ...model.error import *
 from ...db.database import db
 from ...model.enums import *
 from ...util.questutils import *
+from ...util.format_number import format_number
 
 @description('仅开启时生效，氪体数将取满足条件的最大值，禅模式指不执行体力相关的功能，仅在清日常生效，单项执行将忽略。庆典包括其倍数，加速期间的所有倍数判断均x2')
 @name("全局配置")
@@ -285,235 +285,125 @@ _USER_INFO_DISPLAY_ORDER = (
     '香水', '扫荡券', '加速券', '大师币', '连结币',
 )
 
-_CN_SCALE: Tuple[Tuple[str, int], ...] = (('亿', 10 ** 8), ('万', 10 ** 4))
-_EN_SCALE: Tuple[Tuple[str, int], ...] = (('b', 10 ** 9), ('m', 10 ** 6), ('k', 10 ** 3))
-
-
-def _resolve_scale_unit(val: int, scale: Literal['k', 'm', 'b', '万', '亿']) -> Tuple[int, str]:
-    ladder = _CN_SCALE if scale in ('万', '亿') else _EN_SCALE
-    start = next(i for i, (s, _) in enumerate(ladder) if s == scale)
-    av = abs(val)
-    for i in range(start, len(ladder)):
-        suf, div = ladder[i]
-        if av >= div:
-            return div, suf
-    return 1, ''
-
-
-def _round_scaled_quotient(quotient: Decimal, decimals: int) -> str:
-    if decimals <= 0:
-        n = quotient.quantize(Decimal('1'), rounding=ROUND_HALF_UP)
-        return str(int(n))
-    step = Decimal('1').scaleb(-decimals)
-    n = quotient.quantize(step, rounding=ROUND_HALF_UP)
-    s = format(n, 'f')
-    if '.' in s:
-        s = s.rstrip('0').rstrip('.')
-    return s
-
-
-def _group_int_string(int_part: str, use_grouping: bool) -> str:
-    if not use_grouping or not int_part:
-        return int_part
-    sign = ''
-    if int_part[0] == '-':
-        sign = '-'
-        int_part = int_part[1:]
-    elif int_part[0] == '+':
-        sign = '+'
-        int_part = int_part[1:]
-    rev = int_part[::-1]
-    pieces = [rev[i:i + 3][::-1] for i in range(0, len(rev), 3)]
-    return sign + ','.join(reversed(pieces))
-
-
-def _apply_numeric_separator(num_str: str, mode: Literal['auto', 'no', 'yes'], original_val: int) -> str:
-    if mode == 'no':
-        use = False
-    elif mode == 'yes':
-        use = True
-    else:
-        use = abs(original_val) >= 100_000
-    if '.' in num_str:
-        a, b = num_str.split('.', 1)
-        return _group_int_string(a, use) + '.' + b
-    return _group_int_string(num_str, use)
-
-
-def format_number(
-    val: int,
-    scale: Optional[Literal['k', 'm', 'b', '万', '亿']] = None,
-    decimals: Optional[int] = None,
-    separator: Literal['auto', 'no', 'yes'] = 'auto',
-) -> str:
-    if scale is None:
-        s = str(int(val))
-        return _apply_numeric_separator(s, separator, val)
-    dec = 2 if decimals is None else decimals
-    div, suffix = _resolve_scale_unit(val, scale)
-    if not suffix:
-        s = str(int(val))
-        return _apply_numeric_separator(s, separator, val)
-    q = Decimal(val) / Decimal(div)
-    coeff = _round_scaled_quotient(q, dec)
-    return _apply_numeric_separator(coeff, separator, val) + suffix
-
-
 @description('展示基本信息，固定显示玩家名、体力、等级、钻石、母猪石、全角色战力，可自定义显示其他信息')
 @name('基本信息')
 @default(True)
-@multichoice("user_info_display", "显示信息",
+@multichoice(
+    "user_info_display", "显示信息",
     ['心碎', '星幽碎片', '炼金点数', '香水'],
-    ['玛娜', '心碎', '星球杯', '星幽碎片', '属性球', '大师碎片', '炼金点数', '香水', '扫荡券', '加速券', '大师币', '连结币'])
+    ['玛娜', '心碎', '星球杯', '星幽碎片', '属性球', '大师碎片', '炼金点数', '香水', '扫荡券', '加速券', '大师币', '连结币']
+)
 class user_info(Module):
-    async def do_task(self, client: pcrclient):
-        now = db.format_time(apiclient.datetime)
-        display_items = set(self.get_config('user_info_display'))
+    def _collect_optional_info(self, client: pcrclient, display_items: set[str]) -> dict[str, str]:
+        data = client.data
+        inv = data.get_inventory
 
-        # 固定信息
-        name = client.data.user_name
-        level = client.data.team_level
-        stamina = client.data.stamina
-        max_stamina = db.team_info[client.data.team_level].max_stamina
-        jewel = client.data.jewel.free_jewel + client.data.jewel.jewel
-        pig = client.data.get_inventory((eInventoryType.Item, 90005))
-        tot_power = sum([client.data.get_unit_power(unit) for unit in client.data.unit])
+        def fmt(n: int, **kwargs) -> str:
+            return format_number(n, **kwargs)
 
-        # 可选信息
-        optional_info = {}
-
-        if '玛娜' in display_items:
-            mana = client.data.gold.gold_id_free + client.data.gold.gold_id_pay
-            optional_info['玛娜'] = format_number(mana, scale='亿', decimals=1, separator='no')
-
-        if '心碎' in display_items:
-            heart = client.data.get_inventory(db.heart)
-            xinsui = client.data.get_inventory(db.xinsui)
+        def fmt_heart() -> str:
+            heart = inv(db.heart)
+            xinsui = inv(db.xinsui)
             if heart > 0:
-                optional_info['心碎'] = f"{format_number(xinsui)}(大心 {format_number(heart)})"
-            else:
-                optional_info['心碎'] = format_number(xinsui)
+                return f"{fmt(xinsui)}(大心 {fmt(heart)})"
+            return fmt(xinsui)
 
-        if '星球杯' in display_items:
-            star_cup = client.data.get_inventory(db.xingqiubei)
-            optional_info['星球杯'] = format_number(star_cup)
+        def fmt_balls() -> str:
+            items = [
+                db.fire_ball,
+                db.water_ball,
+                db.wind_ball,
+                db.sun_ball,
+                db.dark_ball,
+            ]
+            return '/'.join(fmt(inv(item)) for item in items)
 
-        if '星幽碎片' in display_items:
-            xinyou = client.data.get_inventory(db.xinyou)
-            optional_info['星幽碎片'] = format_number(xinyou)
-
-        if '属性球' in display_items:
-            fire = client.data.get_inventory(db.fire_ball)
-            water = client.data.get_inventory(db.water_ball)
-            wind = client.data.get_inventory(db.wind_ball)
-            sun = client.data.get_inventory(db.sun_ball)
-            dark = client.data.get_inventory(db.dark_ball)
-            optional_info['属性球'] = f"{format_number(fire)}/{format_number(water)}/{format_number(wind)}/{format_number(sun)}/{format_number(dark)}"
-
-        if '大师碎片' in display_items:
-            master = client.data.get_inventory(db.master_fragment)
-            master_f = client.data.get_inventory(db.master_ffragment)
+        def fmt_master_fragment() -> str:
+            master = inv(db.master_fragment)
+            master_f = inv(db.master_ffragment)
             if master_f > 0:
-                optional_info['大师碎片'] = f"{master}(残片 {master_f})"
-            else:
-                optional_info['大师碎片'] = str(master)
+                return f"{master}(残片 {master_f})"
+            return str(master)
 
-        if '炼金点数' in display_items:
-            alces_pt = client.data.get_inventory(db.ex_rainbow_enhance_pt)
-            optional_info['炼金点数'] = format_number(alces_pt, scale='万', decimals=0, separator='no')
+        handlers = {
+            '玛娜': lambda: fmt(
+                data.gold.gold_id_free + data.gold.gold_id_pay,
+                scale='亿',
+                decimals=1,
+                separator='no',
+            ),
+            '心碎': fmt_heart,
+            '星球杯': lambda: fmt(inv(db.xingqiubei)),
+            '星幽碎片': lambda: fmt(inv(db.xinyou)),
+            '母猪石': lambda: fmt(inv((eInventoryType.Item, 90005))),
+            '属性球': fmt_balls,
+            '大师碎片': fmt_master_fragment,
+            '炼金点数': lambda: fmt(
+                inv(db.ex_rainbow_enhance_pt),
+                scale='万',
+                decimals=0,
+                separator='no',
+            ),
+            '香水': lambda: str(inv(db.ex_rainbow_enhance_ball)),
+            '扫荡券': lambda: fmt(inv((eInventoryType.Item, 23001))),
+            '加速券': lambda: str(inv(db.travel_speed_up_paper)),
+            '大师币': lambda: fmt(
+                inv((eInventoryType.Item, 90008)),
+                scale='万',
+                decimals=1,
+                separator='no',
+            ),
+            '连结币': lambda: str(inv((eInventoryType.Item, 99007))),
+        }
 
-        if '香水' in display_items:
-            perfume = client.data.get_inventory((eInventoryType.Item, 26203))
-            optional_info['香水'] = str(perfume)
+        return {
+            key: handlers[key]()
+            for key in _USER_INFO_DISPLAY_ORDER
+            if key in display_items and key in handlers
+        }
 
-        if '扫荡券' in display_items:
-            sweep_ticket = client.data.get_inventory((eInventoryType.Item, 23001))
-            optional_info['扫荡券'] = format_number(sweep_ticket)
-
-        if '加速券' in display_items:
-            speed_ticket = client.data.get_inventory(db.travel_speed_up_paper)
-            optional_info['加速券'] = str(speed_ticket)
-
-        if '大师币' in display_items:
-            master_coin = client.data.get_inventory((eInventoryType.Item, 90008))
-            optional_info['大师币'] = format_number(master_coin, scale='万', decimals=1, separator='no')
-
-        if '连结币' in display_items:
-            link_coin = client.data.get_inventory((eInventoryType.Item, 99007))
-            optional_info['连结币'] = str(link_coin)
-
-        # 注释掉的琐碎物品（方便后续启用）
-        # if 'EX装备币' in display_items:
-        #     ex_weapon = client.data.get_inventory((eInventoryType.Item, 90009))
-        #     ex_armor = client.data.get_inventory((eInventoryType.Item, 90010))
-        #     ex_accessory = client.data.get_inventory((eInventoryType.Item, 90011))
-        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, separator='no')
-        #     optional_info['EX装备币'] = f"{fmt_coin(ex_weapon)}/{fmt_coin(ex_armor)}/{fmt_coin(ex_accessory)}"
-
-        # if '商店币' in display_items:
-        #     dungeon_coin = client.data.get_inventory((eInventoryType.Item, 90002))
-        #     arena_coin = client.data.get_inventory((eInventoryType.Item, 90003))
-        #     grand_arena_coin = client.data.get_inventory((eInventoryType.Item, 90004))
-        #     clan_coin = client.data.get_inventory((eInventoryType.Item, 90006))
-        #     fmt_coin = lambda n: format_number(n, scale='万', decimals=2, separator='no')
-        #     optional_info['商店币'] = f"{fmt_coin(dungeon_coin)}/{fmt_coin(arena_coin)}/{fmt_coin(grand_arena_coin)}/{fmt_coin(clan_coin)}"
-
-        # if '原矿' in display_items:
-        #     # 原矿 ID 范围通常是 35000-35999，按ID倒序
-        #     ores = [(item_id, client.data.get_inventory((eInventoryType.Item, item_id)))
-        #             for item_id in range(35999, 34999, -1)
-        #             if client.data.get_inventory((eInventoryType.Item, item_id)) > 0]
-        #     if ores:
-        #         optional_info['原矿'] = '/'.join(str(cnt) for _, cnt in ores)
-
-        # if '经验药剂' in display_items:
-        #     # 经验药剂 ID: 20001-20004，按ID倒序
-        #     exp_potions = [client.data.get_inventory((eInventoryType.Item, item_id))
-        #                    for item_id in range(20004, 20000, -1)]
-        #     optional_info['经验药剂'] = '/'.join(
-        #         format_number(cnt, scale='万', decimals=2, separator='auto') for cnt in exp_potions)
-
-        # if '精炼石' in display_items:
-        #     # 精炼石 ID: 22001-22006，按ID倒序
-        #     refine_stones = [client.data.get_inventory((eInventoryType.Item, item_id))
-        #                      for item_id in range(22006, 22000, -1)]
-        #     optional_info['精炼石'] = '/'.join(
-        #         format_number(cnt, scale='万', decimals=2, separator='auto') for cnt in refine_stones)
-
-        # if '好感礼物' in display_items:
-        #     # 蛋糕类 ID: 50001-50003，按ID倒序
-        #     cakes = [client.data.get_inventory((eInventoryType.Item, item_id))
-        #              for item_id in range(50003, 50000, -1)]
-        #     optional_info['好感礼物'] = '/'.join(
-        #         format_number(cnt, scale='万', decimals=2, separator='auto') for cnt in cakes)
-
-        # 输出格式
-        if stamina >= max_stamina:
-            self._warn(f"体力爆了！")
-
-        # 第一行：固定信息
-        self._log(f"{name} 体力{stamina}({max_stamina}) 等级{level} 钻石{format_number(jewel)}")
-
-        # 第二行：可选信息（前两项）+ 母猪石（顺序与配置候选项一致，避免 set 迭代无序）
-        line2_items = []
+    def _log_optional_info(self, optional_info: dict[str, str], pig: int) -> None:
         keys = [k for k in _USER_INFO_DISPLAY_ORDER if k in optional_info]
-        for i in range(min(2, len(keys))):
-            line2_items.append(f"{keys[i]}{optional_info[keys[i]]}")
+
+        line2_items = [
+            f"{key}{optional_info[key]}"
+            for key in keys[:2]
+        ]
         line2_items.append(f"母猪石{format_number(pig)}")
         self._log(' '.join(line2_items))
 
-        # 第三行及以后：每行3个属性
-        remaining_keys = keys[2:]
-        for i in range(0, len(remaining_keys), 3):
-            line_items = []
-            for j in range(3):
-                if i + j < len(remaining_keys):
-                    key = remaining_keys[i + j]
-                    line_items.append(f"{key}{optional_info[key]}")
+        for i in range(2, len(keys), 3):
+            line_items = [
+                f"{key}{optional_info[key]}"
+                for key in keys[i:i + 3]
+            ]
             self._log(' '.join(line_items))
 
-        # 最后一行：全角色战力
-        self._log(f"全角色战力：{format_number(tot_power)}")
-        self._log(f"已氪体数：{client.data.recover_stamina_exec_count}")
+    async def do_task(self, client: pcrclient):
+        data = client.data
+        now = db.format_time(apiclient.datetime)
+        display_items = set(self.get_config('user_info_display'))
+
+        name = data.user_name
+        level = data.team_level
+        stamina = data.stamina
+        max_stamina = db.team_info[level].max_stamina
+        jewel = data.jewel.free_jewel + data.jewel.jewel
+        pig = data.get_inventory((eInventoryType.Item, 90005))
+        total_power = sum(data.get_unit_power(unit) for unit in data.unit)
+
+        if stamina >= max_stamina:
+            self._warn("体力爆了！")
+
+        optional_info = self._collect_optional_info(client, display_items)
+
+        self._log(
+            f"{name} 体力{stamina}({max_stamina}) "
+            f"等级{level} 钻石{format_number(jewel)}"
+        )
+        self._log_optional_info(optional_info, pig)
+
+        self._log(f"全角色战力：{format_number(total_power)}")
+        self._log(f"已氪体数：{data.recover_stamina_exec_count}")
         self._log(f"清日常时间：{now}")
 

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -363,8 +363,8 @@ def format_number(
 @name('基本信息')
 @default(True)
 @multichoice("user_info_display", "显示信息",
-    ['玛娜', '心碎', '星幽碎片', '炼金点数'],
-    ['玛娜', '心碎', '星杯', '星幽碎片', '属性球', '大师碎片', '炼金点数', '香水', '扫荡券', '加速券', '大师币', '连结币'])
+    ['心碎', '星幽碎片', '炼金点数', '香水'],
+    ['玛娜', '心碎', '星球杯', '星幽碎片', '属性球', '大师碎片', '炼金点数', '香水', '扫荡券', '加速券', '大师币', '连结币'])
 class user_info(Module):
     async def do_task(self, client: pcrclient):
         now = db.format_time(apiclient.datetime)
@@ -394,9 +394,9 @@ class user_info(Module):
             else:
                 optional_info['心碎'] = format_number(xinsui)
 
-        if '星杯' in display_items:
+        if '星球杯' in display_items:
             star_cup = client.data.get_inventory(db.xingqiubei)
-            optional_info['星杯'] = format_number(star_cup)
+            optional_info['星球杯'] = format_number(star_cup)
 
         if '星幽碎片' in display_items:
             xinyou = client.data.get_inventory(db.xinyou)

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -344,19 +344,19 @@ def format_number(
     val: int,
     scale: Optional[Literal['k', 'm', 'b', '万', '亿']] = None,
     decimals: Optional[int] = None,
-    seperator: Literal['auto', 'no', 'yes'] = 'auto',
+    separator: Literal['auto', 'no', 'yes'] = 'auto',
 ) -> str:
     if scale is None:
         s = str(int(val))
-        return _apply_numeric_separator(s, seperator, val)
+        return _apply_numeric_separator(s, separator, val)
     dec = 2 if decimals is None else decimals
     div, suffix = _resolve_scale_unit(val, scale)
     if not suffix:
         s = str(int(val))
-        return _apply_numeric_separator(s, seperator, val)
+        return _apply_numeric_separator(s, separator, val)
     q = Decimal(val) / Decimal(div)
     coeff = _round_scaled_quotient(q, dec)
-    return _apply_numeric_separator(coeff, seperator, val) + suffix
+    return _apply_numeric_separator(coeff, separator, val) + suffix
 
 
 @description('展示基本信息，固定显示玩家名、体力、等级、钻石、母猪石、全角色战力，可自定义显示其他信息')

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -281,7 +281,7 @@ class jjc_reward(Module):
         self._log(f"pjjc币x{info.reward_info.count}")
 
 _USER_INFO_DISPLAY_ORDER = (
-    '玛娜', '心碎', '星杯', '星幽碎片', '属性球', '大师碎片', '炼金点数',
+    '玛娜', '心碎', '星球杯', '星幽碎片', '属性球', '大师碎片', '炼金点数',
     '香水', '扫荡券', '加速券', '大师币', '连结币',
 )
 

--- a/autopcr/module/modules/daily.py
+++ b/autopcr/module/modules/daily.py
@@ -353,7 +353,7 @@ class user_info(Module):
                 decimals=1,
                 separator='no',
             ),
-            '连结币': lambda: str(inv((eInventoryType.Item, 99007))),
+            '连结币': lambda: str(inv((eInventoryType.Item, 90012))),
         }
 
         return {

--- a/autopcr/util/format_number.py
+++ b/autopcr/util/format_number.py
@@ -1,0 +1,44 @@
+from typing import Literal, Optional
+
+SCALES = {
+    '亿': [('亿', 10 ** 8), ('万', 10 ** 4)],
+    '万': [('万', 10 ** 4)],
+    'b': [('b', 10 ** 9), ('m', 10 ** 6), ('k', 10 ** 3)],
+    'm': [('m', 10 ** 6), ('k', 10 ** 3)],
+    'k': [('k', 10 ** 3)],
+}
+
+def _trim_float(s: str) -> str:
+    return s.rstrip('0').rstrip('.') if '.' in s else s
+
+def _add_separator(s: str, val: int, mode: Literal['auto', 'no', 'yes']) -> str:
+    if mode == 'no':
+        return s
+
+    use_separator = mode == 'yes' or abs(val) >= 100_000
+    if not use_separator:
+        return s
+
+    if '.' in s:
+        int_part, frac_part = s.split('.', 1)
+        return f"{int(int_part):,}.{frac_part}"
+
+    return f"{int(s):,}"
+
+def format_number(
+    val: int,
+    scale: Optional[Literal['k', 'm', 'b', '万', '亿']] = None,
+    decimals: int = 2,
+    separator: Literal['auto', 'no', 'yes'] = 'auto',
+) -> str:
+    if scale is None:
+        return _add_separator(str(int(val)), val, separator)
+
+    for suffix, div in SCALES[scale]:
+        if abs(val) >= div:
+            num = val / div
+            s = _trim_float(f"{num:.{decimals}f}")
+            return _add_separator(s, val, separator) + suffix
+
+    return _add_separator(str(int(val)), val, separator)
+

--- a/autopcr/util/unit_recognizer.py
+++ b/autopcr/util/unit_recognizer.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, OrderedDict as OrderedDictType
 
 import cv2
 import numpy as np
@@ -41,7 +41,7 @@ class UnitRecognizer:
         self._hist_centered_arr: np.ndarray = np.empty((0, 0), dtype=np.float32)
         self._hist_norm_arr: np.ndarray = np.empty((0,), dtype=np.float32)
         self._template_scaled_cache: Dict[int, List[np.ndarray]] = {}
-        self._unit_result_cache: OrderedDict[bytes, Tuple[int, int]] = OrderedDict()
+        self._unit_result_cache: OrderedDictType[bytes, Tuple[int, int]] = OrderedDict()
         self._unit_result_cache_max = 4096
         self.init = False
         self.ver = None
@@ -134,7 +134,7 @@ class UnitRecognizer:
         return img.crop((x, y, x + w, y + h))
 
     @staticmethod
-    def _save_lru_result(cache: OrderedDict[bytes, Tuple[int, int]], key: bytes, value: Tuple[int, int], max_size: int):
+    def _save_lru_result(cache: OrderedDictType[bytes, Tuple[int, int]], key: bytes, value: Tuple[int, int], max_size: int):
         cache[key] = value
         cache.move_to_end(key)
         if len(cache) > max_size:


### PR DESCRIPTION
1. 改进基本信息的显示，改为默认显示心碎、星幽碎片、炼金点数和香水而不是玛娜和扫荡券，可配置。
2. Hoshino 还是用的 Python 3.8，`collections.OrderedDict` 不能当范型使用。
类型标注需要用 `typing.OrderedDict`