### PR TITLE
ci: build docker image for dev branch

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
     tags:
       - 'v*'
 
@@ -56,6 +57,8 @@ jobs:
             type=match,pattern=^v(\d{8}-\d+)$,group=1
             type=match,pattern=^v(\d{8})-\d+$,group=1
             type=raw,value=ci-{{commit_date 'YYYYMMDD-HHmmss' tz='Asia/Shanghai'}}-{{sha}},enable=${{ github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' && !startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=dev-{{commit_date 'YYYYMMDD-HHmmss' tz='Asia/Shanghai'}}-{{sha}},enable=${{ github.ref == 'refs/heads/dev' && !startsWith(github.ref, 'refs/tags/') }}
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 


### PR DESCRIPTION
为dev分支也构建docker镜像，便于docker部署用户也能体验测试dev分支更新