### PR TITLE
Fix gacha level check in gacha.py

### DIFF
--- a/autopcr/module/modules/gacha.py
+++ b/autopcr/module/modules/gacha.py
@@ -138,7 +138,7 @@ class role_gacha(Module):
         current_ticket_cnt = client.data.get_inventory(db.unit_role_gach_ticket)
         cnt = 0
         while current_ticket_cnt > 0:
-            times = min(client.data.settings.unit_role.gacha_exec_limit, current_ticket_cnt, (db.unit_role_gacha_level[resp.gacha_level + 1].exec_count - resp.exec_count) if resp.gacha_level in db.unit_role_gacha_level else current_ticket_cnt)
+            times = min(client.data.settings.unit_role.gacha_exec_limit, current_ticket_cnt, (db.unit_role_gacha_level[resp.gacha_level + 1].exec_count - resp.exec_count) if resp.gacha_level + 1 in db.unit_role_gacha_level else current_ticket_cnt)
             resp = await client.unit_role_gacha_exec(times, current_ticket_cnt)
             current_ticket_cnt -= times
             cnt += times


### PR DESCRIPTION
你这判断的 key 和读取的 key 不一致，可能出现“当前等级存在，但下一等级不存在”，随后访问下一等级时触发 KeyError