### PR TITLE
Use gtlv-py as default validator

### DIFF
--- a/autopcr/http_server/validator.py
+++ b/autopcr/http_server/validator.py
@@ -30,7 +30,9 @@ def create_validator(qq):
 
 async def Validator(qq):
     info = None
-    for validator in [remoteValidator, localValidator, lambda: manualValidator(qq)]:
+    # 本地求解在进程内完成，无需外部服务，故排在最前；remoteValidator 是排队制的第三方农场，
+    # 单次可耗时数十秒，退居其后作兜底。
+    for validator in [localValidator, remoteValidator, lambda: manualValidator(qq)]:
         try:
             info = await validator()
             if info:

--- a/autopcr/sdk/validator.py
+++ b/autopcr/sdk/validator.py
@@ -4,40 +4,38 @@ import asyncio
 from ..util import aiorequests
 from ..util.logger import instance as logger
 
+_gtlv_client = None
+_gtlv_client_lock = asyncio.Lock()
+
+async def _get_gtlv_client():
+    # 复用同一个 Client：它在首次遇到点选验证码时加载识别模型，这项开销只应付出一次。
+    global _gtlv_client
+    if _gtlv_client is None:
+        async with _gtlv_client_lock:
+            if _gtlv_client is None:
+                from gtlv import Client
+                _gtlv_client = Client(max_attempts=3)
+    return _gtlv_client
+
 async def localValidator():
     logger.info('use local validator')
 
     from .bsgamesdk import captch
     cap = await captch()
-    challenge = cap['challenge']
-    gt = cap['gt']
-    userid = cap['gt_user_id']
 
-    import bili_ticket_gt_python
-    gt_obj = bili_ticket_gt_python.ClickPy()
-    _type = None
     info = None
-
     try:
-        n = 3
-        for _ in range(n):
-            try:
-                _type = gt_obj.get_type(gt, challenge, None)
-                break
-            except Exception as e:
-                pass
-
-        if _type == 'click':
-            (c, s, args) = gt_obj.get_new_c_s_args(gt, challenge)
-            cor = asyncio.sleep(2)
-            w = gt_obj.generate_w(gt_obj.calculate_key(args), gt, challenge, str(c), s, "abcdefghijklmnop")
-            await cor
-            (msg, validate) = gt_obj.verify(gt, challenge, w)
-            info = {
-                "challenge": challenge,
-                "gt_user_id": userid,
-                "validate": validate
-            }
+        client = await _get_gtlv_client()
+        # 必须沿用 start_captcha 下发的这一组 gt/challenge：登录接口不提交 gt，
+        # 服务端按自己的 gt 校验 (challenge, validate)，另行登记得到的 validate 不被接受。
+        result = await client.solve(cap['gt'], cap['challenge'])
+        info = {
+            # 滑动流程会换用新的 challenge，须提交 result.challenge 而非传入的那个。
+            "challenge": result.challenge,
+            "gt_user_id": cap['gt_user_id'],
+            "validate": result.validate
+        }
+        logger.info(f'local validator solved a {result.captcha_type} captcha')
     except Exception as e:
         logger.error(f'local validator error: {e}')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "quart-compress>=0.2.1,<0.3",
     "dataclasses-json>=0.6.4,<0.7",
     "pulp>=2.8.0,<3",
-    "bili-ticket-gt-python>=0.2.7,<0.4"
+    "gtlv>=0.1.2,<0.2"
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp~=3.8.4
 aiofile~=3.9.0
-bili_ticket_gt_python==0.2.7
+gtlv~=0.1.2
 msgpack~=1.0.2
 pycryptodome~=3.14.1
 requests~=2.27.1


### PR DESCRIPTION
换用半自研本地推理验证器，项目地址：https://github.com/cca2878/gtlv-py
已用真实账号实测完整登录流程成功。
其各项指标明显优于旧localValidator实现，相比其最新版仍持平或略优。
使用abi3编译wheel，对齐项目要求python >= 3.10。且无需外部C库，理论上适用绝大部分环境，兼容更广。
所以顺便提升为了默认validator。

项目`requirements.txt` 现钉 `bili_ticket_gt_python==0.2.7`。其最新版为 `0.3.3`，改动较大。
实际测试数据如下
| 相关指标 | btgp `0.2.7`（现钉） | btgp `0.3.3`（最新） | gtlv `0.1.3` |
|---|---|---|---|
| 单次求解通过率（50次测试） | 72.0% | 90.0% | **94.0%** |
| 单次求解总耗时 | 2.2~2.9 s | 2.2~2.8 s | ~2.85 s |
| 单次求解阻塞事件循环 | ~0.61 s | ~0.53 s | **0 s** |
| 首次加载模型阻塞事件循环 | ~0.6 s | ~0.6 s | **0 s** |
| 存储空间占用合计 | 139 MB | 104 MB | **86 MB** |
| 自包含（无运行时下载） | **是** | 否 | **是** |
| 载入模型后常驻内存 | 270 MB | 292 MB | **136 MB** |