### PR TITLE
perf: 优化资源清单内存占用并延迟加载

### DIFF
--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -78,7 +78,7 @@ class datamgr(BaseModel, Component[apiclient]):
     async def try_update_database(ver: int):
         async with _data_lck:
             if not assetmgr.ver or assetmgr.ver < ver:
-                await assetmgr.init(ver)
+                assetmgr.set_version(ver)
             if not dbmgr.ver or dbmgr.ver < assetmgr.ver: 
                 await dbmgr.update_db(assetmgr)
                 db.update(dbmgr)

--- a/autopcr/db/assetmgr.py
+++ b/autopcr/db/assetmgr.py
@@ -1,4 +1,5 @@
 #type: ignore
+import asyncio
 import json
 import os
 from typing import Dict, Set, Tuple
@@ -24,7 +25,9 @@ ROOT_MANIFEST = "manifest/manifest_assetmanifest"
 class assetmgr:
     def __init__(self):
         self.ver = None
+        self._loaded_ver = None
         self.registries: AssetRegistry = {}
+        self._manifest_lock = asyncio.Lock()
 
     res = 'https://l1-prod-patch-gzlj.bilibiligame.net/client_ob_771'
 
@@ -186,7 +189,7 @@ class assetmgr:
             raise ValueError(f'remote manifest {ver} contains no assets')
         return registry
 
-    async def init(self, ver):
+    async def _load_registry(self, ver: int) -> AssetRegistry:
         os.makedirs(self._manifest_dir(), exist_ok=True)
         compact_path = self._compact_cache_path(ver)
         legacy_path = self._legacy_cache_path(ver)
@@ -213,15 +216,51 @@ class assetmgr:
                 registry = await self._fetch_registry(ver)
                 logger.info(f'manifest version {ver} loaded from remote')
 
-            self._write_compact_cache(compact_path, ver, registry)
+            # registry 已在内存可用，缓存写失败（如磁盘满）不应阻断本次加载
+            try:
+                self._write_compact_cache(compact_path, ver, registry)
+            except OSError as e:
+                logger.warning(f'failed to write compact manifest version {ver}: {e}')
 
-        self.registries = registry
+        return registry
+
+    def set_version(self, ver: int):
         self.ver = ver
+
+    async def _ensure_loaded_locked(self, ver: int):
+        if self._loaded_ver == ver:
+            return
+
+        registry = await self._load_registry(ver)
+        self.registries = registry
+        self._loaded_ver = ver
+
+    async def ensure_loaded(self, ver=None):
+        # 在锁内取版本号，避免等锁期间版本切换导致按旧版本多做一次重载
+        async with self._manifest_lock:
+            target_ver = self.ver if ver is None else ver
+            if target_ver is None:
+                raise RuntimeError('asset manifest version is not set')
+
+            await self._ensure_loaded_locked(target_ver)
+
+    async def init(self, ver):
+        self.set_version(ver)
+        await self.ensure_loaded(ver)
+
+    async def _resolve_asset(self, url: str) -> AssetEntry:
+        async with self._manifest_lock:
+            target_ver = self.ver
+            if target_ver is None:
+                raise RuntimeError('asset manifest version is not set')
+
+            await self._ensure_loaded_locked(target_ver)
+            return self.registries[url]
 
     async def download(self, url: str) -> bytes:
         logger.info(f"resolving {url}...")
 
-        md5, category = self.registries[url]
+        md5, category = await self._resolve_asset(url)
         download_url = f'{self.pool}/{category}/{md5[:2]}/{md5}'
         return await (await aiorequests.get(download_url)).content
 

--- a/autopcr/db/assetmgr.py
+++ b/autopcr/db/assetmgr.py
@@ -1,105 +1,230 @@
 #type: ignore
-from typing import List
-from ..util import aiorequests
-from ..util.logger import instance as logger
-from ..constants import CACHE_DIR
-import os, pydantic
+import json
+import os
+from typing import Dict, Set, Tuple
+
+import msgpack
 import UnityPy
 from UnityPy.enums import ClassIDType
+
+from ..constants import CACHE_DIR
+from ..util import aiorequests
 from ..util.logger import instance as logger
+
 UnityPy.config.FALLBACK_UNITY_VERSION = "2021.3.20f1"
 
-class content(pydantic.BaseModel):
-    url: str = None
-    md5: str = None
-    type: str = None
-    category: str = None
-    size: int = 0
-    children: List["content"] = None
+AssetEntry = Tuple[str, str]
+AssetRegistry = Dict[str, AssetEntry]
 
-    @property
-    def is_assets(self) -> bool:
-        return not self.url.startswith('manifest/')
+COMPACT_MANIFEST_FORMAT = 1
+MANIFEST_CATEGORY = "AssetBundles/Android"
+ROOT_MANIFEST = "manifest/manifest_assetmanifest"
 
-    @staticmethod
-    def from_line(line: str, category: str) -> "content":
-        splits = line.split(',')
-        offset = len(splits) > 5
-        return content(
-            url=splits[0],
-            md5=splits[1],
-            type=splits[2 + offset],
-            size=int(splits[3 + offset]),
-            category=category,
-            children=[]
-        )
-    
-    @staticmethod
-    async def from_url(urlroot: str, url: str, category: str) -> List["content"]:
-        lines = (await (await aiorequests.get(f'{urlroot}{url}')).text).split('\n')
-        res = [content.from_line(line, category) for line in lines]
-        for child in res:
-            await child.download_children(urlroot)
-        return res
-
-    async def download_children(self, urlroot: str):
-        if not self.is_assets:
-            self.children = await content.from_url(urlroot, self.url, self.category)
-
-    def register_to(self, mgr: "assetmgr"):
-        mgr.registries[self.url] = self
-        for child in self.children:
-            child.register_to(mgr)
-        
-    async def download(self, urlgetter) -> bytes:
-        return await (await aiorequests.get(urlgetter(self.md5))).content
 
 class assetmgr:
     def __init__(self):
         self.ver = None
-        self.root = None
-        self.registries: dict[str, content] = {}
+        self.registries: AssetRegistry = {}
 
     res = 'https://l1-prod-patch-gzlj.bilibiligame.net/client_ob_771'
 
     @property
     def manifest(self) -> str:
         return f'{self.res}/Manifest'
-    
+
     @property
     def pool(self) -> str:
         return f'{self.res}/pool'
 
-    async def init(self, ver):
-        self.registries.clear()
+    @staticmethod
+    def _manifest_dir() -> str:
+        return os.path.join(CACHE_DIR, 'manifest')
 
-        os.makedirs(os.path.join(CACHE_DIR, 'manifest'), exist_ok=True)
-        cacheFile = os.path.join(CACHE_DIR, 'manifest', f'{ver}.json')
+    @classmethod
+    def _compact_cache_path(cls, ver: int) -> str:
+        return os.path.join(cls._manifest_dir(), f'{ver}.compact.msgpack')
+
+    @classmethod
+    def _legacy_cache_path(cls, ver: int) -> str:
+        return os.path.join(cls._manifest_dir(), f'{ver}.json')
+
+    @staticmethod
+    def _validate_registry(raw_assets, ver: int) -> AssetRegistry:
+        # 紧凑格式按 category 分组存储，避免同一 category 字符串在每个条目里重复一遍
+        if not isinstance(raw_assets, dict):
+            raise ValueError(f'compact manifest {ver} assets must be a map')
+
+        registry: AssetRegistry = {}
+        for category, urls in raw_assets.items():
+            if not isinstance(category, str) or not category:
+                raise ValueError(f'compact manifest {ver} contains an invalid category')
+            if not isinstance(urls, dict):
+                raise ValueError(f'compact manifest {ver} assets for {category} must be a map')
+            for url, md5 in urls.items():
+                if not isinstance(url, str) or not url:
+                    raise ValueError(f'compact manifest {ver} contains an invalid URL')
+                if not isinstance(md5, str) or not md5:
+                    raise ValueError(f'compact manifest {ver} contains an invalid md5 for {url}')
+                registry[url] = (md5, category)
+
+        if not registry:
+            raise ValueError(f'compact manifest {ver} contains no assets')
+        return registry
+
+    @classmethod
+    def _load_compact_cache(cls, path: str, ver: int) -> AssetRegistry:
+        with open(path, 'rb') as f:
+            payload = msgpack.unpackb(f.read(), raw=False)
+
+        if not isinstance(payload, dict):
+            raise ValueError(f'compact manifest {ver} must be a map')
+        if payload.get('format') != COMPACT_MANIFEST_FORMAT:
+            raise ValueError(f'unsupported compact manifest format for version {ver}')
+        if payload.get('version') != ver:
+            raise ValueError(f'compact manifest version mismatch: expected {ver}')
+        return cls._validate_registry(payload.get('assets'), ver)
+
+    @classmethod
+    def _load_legacy_cache(cls, path: str, ver: int) -> AssetRegistry:
+        with open(path, 'r', encoding='utf-8') as f:
+            root = json.load(f)
+
+        # 同一 URL 会同时出现在 xxx_assetmanifest 与后继的 xxx_assetmanifest_s 中，
+        # 只有后者的 hash 在 pool 里真实存在，因此必须按先序遍历让后出现的条目覆盖前者
+        registry: AssetRegistry = {}
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if not isinstance(node, dict):
+                raise ValueError(f'legacy manifest {ver} contains a non-object node')
+
+            children = node.get('children') or []
+            if not isinstance(children, list):
+                raise ValueError(f'legacy manifest {ver} contains invalid children')
+            stack.extend(reversed(children))
+
+            url = node.get('url')
+            if not isinstance(url, str) or not url or url.startswith('manifest/'):
+                continue
+            md5 = node.get('md5')
+            category = node.get('category')
+            if not isinstance(md5, str) or not md5:
+                raise ValueError(f'legacy manifest {ver} contains an invalid md5 for {url}')
+            if not isinstance(category, str) or not category:
+                raise ValueError(f'legacy manifest {ver} contains an invalid category for {url}')
+            registry[url] = (md5, category)
+
+        if not registry:
+            raise ValueError(f'legacy manifest {ver} contains no assets')
+        return registry
+
+    @classmethod
+    def _write_compact_cache(cls, path: str, ver: int, registry: AssetRegistry):
+        assets: Dict[str, Dict[str, str]] = {}
+        for url, (md5, category) in registry.items():
+            assets.setdefault(category, {})[url] = md5
+        payload = {
+            'format': COMPACT_MANIFEST_FORMAT,
+            'version': ver,
+            'assets': assets,
+        }
+        data = msgpack.packb(payload, use_bin_type=True)
+        temporary_path = f'{path}.{os.getpid()}.tmp'
         try:
-            self.root = content.parse_file(cacheFile)
-            
-            logger.info(f'manifest version {ver} loaded from cache')
-        except:
-            self.root = content(
-                url='manifest/manifest_assetmanifest',
-                type='every',
-                category='AssetBundles/Android',
-                children=await content.from_url(f'{self.manifest}/AssetBundles/Android/{ver}/', 'manifest/manifest_assetmanifest', 'AssetBundles/Android')
-            )
-            with open(cacheFile, 'w') as f:
-                f.write(self.root.json())
+            with open(temporary_path, 'wb') as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temporary_path, path)
+        finally:
+            if os.path.exists(temporary_path):
+                os.remove(temporary_path)
 
+    async def _fetch_manifest(
+        self,
+        urlroot: str,
+        manifest_url: str,
+        category: str,
+        registry: AssetRegistry,
+        visited: Set[str],
+    ):
+        if manifest_url in visited:
+            return
+        visited.add(manifest_url)
+
+        response = await aiorequests.get(f'{urlroot}{manifest_url}')
+        lines = (await response.text).splitlines()
+        for line_number, raw_line in enumerate(lines, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            fields = line.split(',')
+            if len(fields) < 4:
+                raise ValueError(f'invalid manifest line {manifest_url}:{line_number}')
+
+            url, md5 = fields[0], fields[1]
+            if not url:
+                raise ValueError(f'empty asset URL at {manifest_url}:{line_number}')
+            if url.startswith('manifest/'):
+                await self._fetch_manifest(urlroot, url, category, registry, visited)
+            else:
+                if not md5:
+                    raise ValueError(f'empty asset md5 at {manifest_url}:{line_number}')
+                registry[url] = (md5, category)
+
+    async def _fetch_registry(self, ver: int) -> AssetRegistry:
+        registry: AssetRegistry = {}
+        urlroot = f'{self.manifest}/{MANIFEST_CATEGORY}/{ver}/'
+        await self._fetch_manifest(
+            urlroot,
+            ROOT_MANIFEST,
+            MANIFEST_CATEGORY,
+            registry,
+            set(),
+        )
+        if not registry:
+            raise ValueError(f'remote manifest {ver} contains no assets')
+        return registry
+
+    async def init(self, ver):
+        os.makedirs(self._manifest_dir(), exist_ok=True)
+        compact_path = self._compact_cache_path(ver)
+        legacy_path = self._legacy_cache_path(ver)
+        registry = None
+
+        try:
+            registry = self._load_compact_cache(compact_path, ver)
+            logger.info(f'compact manifest version {ver} loaded from cache')
+        except FileNotFoundError:
+            pass
+        except (OSError, ValueError, TypeError, msgpack.ExtraData, msgpack.FormatError, msgpack.StackError) as e:
+            logger.warning(f'failed to load compact manifest version {ver}: {e}')
+
+        if registry is None:
+            try:
+                registry = self._load_legacy_cache(legacy_path, ver)
+                logger.info(f'legacy manifest version {ver} loaded from cache')
+            except FileNotFoundError:
+                pass
+            except (OSError, ValueError, TypeError, json.JSONDecodeError) as e:
+                logger.warning(f'failed to load legacy manifest version {ver}: {e}')
+
+            if registry is None:
+                registry = await self._fetch_registry(ver)
+                logger.info(f'manifest version {ver} loaded from remote')
+
+            self._write_compact_cache(compact_path, ver, registry)
+
+        self.registries = registry
         self.ver = ver
-        self.root.register_to(self)
 
     async def download(self, url: str) -> bytes:
         logger.info(f"resolving {url}...")
-        
-        content = self.registries[url]
-        def genHash(hash):
-            return f'{self.pool}/{content.category}/{hash[:2]}/{hash}'
-        return await content.download(genHash)
- 
+
+        md5, category = self.registries[url]
+        download_url = f'{self.pool}/{category}/{md5[:2]}/{md5}'
+        return await (await aiorequests.get(download_url)).content
+
     async def db(self) -> bytes:
         ab = UnityPy.load(await self.download('a/masterdata_master.unity3d'))
         asset = ab.objects[0].read()
@@ -124,4 +249,3 @@ class assetmgr:
 
 # should lock before use
 instance = assetmgr()
-

--- a/autopcr/db/assetmgr.py
+++ b/autopcr/db/assetmgr.py
@@ -236,12 +236,18 @@ class assetmgr:
         self._loaded_ver = ver
 
     async def ensure_loaded(self, ver=None):
-        # 在锁内取版本号，避免等锁期间版本切换导致按旧版本多做一次重载
+        target_ver = self.ver if ver is None else ver
+        if target_ver is None:
+            raise RuntimeError('asset manifest version is not set')
+
+        # 稳态无锁快路径：其原子性依赖"此检查与调用方读取 registries 之间没有 await 点"，
+        # registries 与 _loaded_ver 在 _ensure_loaded_locked 中也是无挂起点地成对更新
+        if self._loaded_ver == target_ver:
+            return
+
+        # 在锁内重取版本号，避免等锁期间版本切换导致按旧版本多做一次重载
         async with self._manifest_lock:
             target_ver = self.ver if ver is None else ver
-            if target_ver is None:
-                raise RuntimeError('asset manifest version is not set')
-
             await self._ensure_loaded_locked(target_ver)
 
     async def init(self, ver):
@@ -249,13 +255,8 @@ class assetmgr:
         await self.ensure_loaded(ver)
 
     async def _resolve_asset(self, url: str) -> AssetEntry:
-        async with self._manifest_lock:
-            target_ver = self.ver
-            if target_ver is None:
-                raise RuntimeError('asset manifest version is not set')
-
-            await self._ensure_loaded_locked(target_ver)
-            return self.registries[url]
+        await self.ensure_loaded()
+        return self.registries[url]
 
     async def download(self, url: str) -> bytes:
         logger.info(f"resolving {url}...")


### PR DESCRIPTION
## 背景

AutoPCR 启动时会将游戏资源 manifest 递归解析为完整的 Pydantic 对象树，并长期保存在内存中。实际资源清单包含约 7.4 万条资源记录，旧实现会使空闲服务占用约 500 MiB 内存；每个版本的 JSON 缓存约 25 MB 并随版本更替持续累积。同时，即使本地数据库已经存在，启动过程仍会主动加载完整资源 manifest。

本 PR 在保持现有接口和资源下载行为不变的前提下，降低资源索引的常驻内存与磁盘占用，并避免启动时不必要的 manifest 加载。

## 主要改动

### 1. 使用紧凑的扁平资源索引

将递归 Pydantic 对象树替换为 `资源 URL -> (hash, category)` 的扁平字典。以下接口行为保持不变：

- `assetmgr.init(ver)` / `assetmgr.ver`
- `db()` / `unit_icon()` / `ex_equip_icon()`

### 2. 增加版本化 compact 缓存

使用项目已有的 `msgpack` 依赖（apiclient 在用）将索引保存为 `cache/manifest/<version>.compact.msgpack`，category 按组存储一次，不再逐条重复。加载顺序：

1. 有效的 compact 缓存
2. 旧 JSON 缓存迁移
3. 远端 manifest

旧 JSON 在迁移后仍然保留，方便回滚。compact 缓存使用同目录临时文件、`fsync` 和 `os.replace` 原子写入；损坏、格式或版本不匹配的缓存会记录原因并逐级回退；写入失败（如磁盘满）只告警不阻断本次加载（registry 已在内存可用）。

### 3. 远端直接构建扁平索引

远端 manifest 不再解析成对象树，而是逐行读取直接写入扁平映射。忽略空行，用 visited 集合避免重复或循环引用，manifest 节点本身不进入资源 registry，只有完整索引构造成功后才替换内存状态。

### 4. 延迟加载资源 manifest

区分目标版本 `ver` 与已加载版本 `_loaded_ver`：`set_version(ver)` 只更新目标版本，`download()` 在第一次解析资源前自动加载索引；并发首次请求通过异步锁合并为一次加载，版本切换期间不会暴露未完成的 registry。`init(ver)` 保持原有 eager 加载兼容行为。

### 5. 已有数据库启动不再加载 manifest

`datamgr.try_update_database()` 现在只设置资源目标版本。本地数据库已存在时直接打开 SQLite，不读取 manifest 也不访问网络；只有数据库缺失并调用 `assetmgr.db()` 时才触发 manifest 加载。数据库原子下载、unhash 及图片磁盘缓存行为保持不变。

## 行为一致性

manifest 中同一 URL 会同时出现在 `xxx_assetmanifest`（32 位 md5）与其后的 `xxx_assetmanifest_s`（16 位 hash）中，而 pool 里只有后者真实存在（HEAD 实测前者 404、后者 200）。因此解析必须保持原实现"先序遍历、后写覆盖"的语义，本实现对此有专门处理和注释，并做了以下验证：

- 用真实 25 MB manifest 迁移后与旧实现的 registry 逐条比对，74,116 条完全一致
- masterdata 端到端：下载 bundle → 解出合法 SQLite（43 MB）
- compact 缓存写入后重载，与迁移来源逐条一致

## 兼容性

- 不修改现有公开调用方式，不增加或升级依赖，不修改 lockfile
- 不删除旧 JSON manifest，compact 文件可以安全删除并重新生成
- 不修改数据库格式与图片磁盘缓存格式
- 本地数据库存在时，即使暂时无法访问 manifest 服务，应用仍可启动

## 效果

74,116 条资源记录的真实 manifest：

| | 旧实现 | 本 PR |
| --- | ---: | ---: |
| 缓存体积/版本 | 25.1 MB (JSON) | 3.89 MB (msgpack, -85%) |
| 缓存冷加载 | 0.35 s | 0.02 s |

内存（Linux/amd64 Docker，同一份数据库与 manifest）：

| 场景 | Docker 内存 | 进程 RSS |
| --- | ---: | ---: |
| 旧递归 Pydantic 实现 | 518.3 MiB | 502.9 MiB |
| 已有数据库，manifest 未加载 | 192.2 MiB | 200.7 MiB |
| compact manifest 已加载 | 219.6 MiB | 228.9 MiB |

空闲内存相对旧实现下降约 63%，加载 compact 索引后仍下降约 58%。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
