### PR TITLE
增加职能精通查询与库存导出功能

### DIFF
--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -16,24 +16,8 @@ from asyncio import Lock
 
 _data_lck = Lock()
 
-UNIT_ROLE_MASTERY_PARAM_NAMES = {
-    1: "生命值",
-    2: "攻击力",
-    3: "物理防御力",
-    4: "魔法防御力",
-    5: "暴击",
-    6: "暴击伤害",
-    7: "造成伤害",
-    8: "异常状态命中",
-    9: "异常状态抵抗",
-    10: "普通攻击",
-    11: "增益效果",
-    12: "减益效果",
-    13: "回复效果",
-    14: "技能值充能",
-}
-
 UNIT_ROLE_MASTERY_UNIVERSAL_ITEM_BASE_ID = 80000
+UNIT_ROLE_MASTERY_LEVELS = tuple(range(1, 6))
 
 class datamgr(BaseModel, Component[apiclient]):
     ready: bool = False
@@ -706,45 +690,6 @@ class datamgr(BaseModel, Component[apiclient]):
             msg.append(f"{db.unit_role_type[role_info.unit_role_id].unit_role_name}{self.get_role_level_single(role_info)}")
         return "\n".join(msg)
 
-    def get_unit_role_mastery_attributes(
-        self,
-        mastery_id: int,
-        slot_level: int,
-        enhance_level: int,
-        enhance_data=None,
-    ) -> typing.Counter[int]:
-        if enhance_data is None:
-            enhance_data = db.unit_role_mastery_enhance_data
-        row = enhance_data.get(mastery_id, {}).get((slot_level, enhance_level))
-        attributes = Counter()
-        if not row:
-            return attributes
-
-        for index in range(1, 3):
-            param_type = getattr(row, f"role_param_type_{index}", 0)
-            value = getattr(row, f"enhance_value_{index}", 0)
-            if param_type:
-                attributes[param_type] += value
-        return attributes
-
-    @staticmethod
-    def format_unit_role_mastery_attributes(attributes: typing.Counter[int]) -> str:
-        msg = []
-        for param_type, value in sorted(attributes.items()):
-            name = UNIT_ROLE_MASTERY_PARAM_NAMES.get(param_type, f"未知属性{param_type}")
-            sign = "-" if value < 0 else "+"
-            value = abs(value)
-            # 技能值充能以 0.1 TP 记录，其余精通属性以 0.01% 记录。
-            scale = 10 if param_type == 14 else 100
-            integer, decimal = divmod(value, scale)
-            formatted_value = str(integer)
-            if decimal:
-                precision = 1 if scale == 10 else 2
-                formatted_value += f".{decimal:0{precision}d}".rstrip("0")
-            suffix = "" if param_type == 14 else "%"
-            msg.append(f"{name}{sign}{formatted_value}{suffix}")
-        return "/".join(msg) or "-"
-
     def get_unit_role_mastery_upgrade_cost(
         self,
         mastery_id: int,
@@ -781,6 +726,93 @@ class datamgr(BaseModel, Component[apiclient]):
             "universal_stock": universal_stock,
             "gap": max(need - stock - universal_stock, 0),
         }
+
+    def get_unit_role_mastery_universal_stocks(self) -> Dict[int, int]:
+        return {
+            slot_level: self.get_inventory((
+                eInventoryType.Item,
+                UNIT_ROLE_MASTERY_UNIVERSAL_ITEM_BASE_ID + slot_level,
+            ))
+            for slot_level in UNIT_ROLE_MASTERY_LEVELS
+        }
+
+    @staticmethod
+    def _is_unit_role_mastery_next_level(
+        current: Tuple[int, int],
+        next_level: Tuple[int, int],
+        states: List[Tuple[int, int]],
+    ) -> bool:
+        if next_level[0] == current[0]:
+            return next_level[1] == current[1] + 1
+        next_enhance_levels = [
+            state[1] for state in states if state[0] == next_level[0]
+        ]
+        return (
+            bool(next_enhance_levels)
+            and next_level[0] == current[0] + 1
+            and next_level[1] == min(next_enhance_levels)
+        )
+
+    def get_unit_role_mastery_reachable_level(
+        self,
+        mastery_id: int,
+        slot_level: int,
+        enhance_level: int,
+        use_universal: bool,
+        enhance_data=None,
+        mastery_level=None,
+        item_data=None,
+    ) -> typing.Optional[Tuple[int, int]]:
+        if enhance_data is None:
+            enhance_data = db.unit_role_mastery_enhance_data
+        if mastery_level is None:
+            mastery_level = db.unit_role_mastery_level
+        if item_data is None:
+            item_data = db.unit_role_mastery_item_data
+
+        states = sorted(enhance_data.get(mastery_id, {}))
+        level_costs = mastery_level.get(mastery_id, {})
+        mastery_items = item_data.get(mastery_id, {})
+        current = (slot_level, enhance_level)
+        if current not in states or not level_costs or not mastery_items:
+            return None
+
+        ordinary_stocks = {
+            level: self.get_inventory((eInventoryType.Item, item.item_id_1))
+            for level, item in mastery_items.items()
+        }
+        universal_stocks = self.get_unit_role_mastery_universal_stocks()
+
+        current_index = states.index(current)
+        while current_index < len(states) - 1:
+            next_level = states[current_index + 1]
+            if not self._is_unit_role_mastery_next_level(current, next_level, states):
+                return None
+
+            cost_data = level_costs.get(current)
+            if not cost_data or current[0] not in mastery_items:
+                return None
+
+            need = cost_data.num
+            ordinary_used = min(ordinary_stocks.get(current[0], 0), need)
+            universal_need = need - ordinary_used
+            if universal_need and (
+                not use_universal
+                or universal_stocks.get(current[0], 0) < universal_need
+            ):
+                break
+
+            ordinary_stocks[current[0]] -= ordinary_used
+            if universal_need:
+                universal_stocks[current[0]] -= universal_need
+            current = next_level
+            current_index += 1
+
+        return current
+
+    @staticmethod
+    def format_unit_role_mastery_level(level: typing.Optional[Tuple[int, int]]) -> str:
+        return f"Lv{level[0]}.{level[1]}" if level else "-"
 
     @staticmethod
     def _unit_role_mastery_slot_name(slot_data, slot_id: int) -> str:
@@ -840,7 +872,7 @@ class datamgr(BaseModel, Component[apiclient]):
                 current_slot_level = getattr(role_info, f"slot_level_{slot_id}", None) if role_info else None
                 current_enhance_level = getattr(role_info, f"enhance_level_{slot_id}", None) if role_info else None
                 current_level = (
-                    f"{current_slot_level}-{current_enhance_level}"
+                    f"Lv{current_slot_level}.{current_enhance_level}"
                     if current_slot_level is not None
                     and current_enhance_level is not None
                     and current_enhance_level >= 0
@@ -853,9 +885,9 @@ class datamgr(BaseModel, Component[apiclient]):
                     "mastery_id": None,
                     "name": f"槽位{slot_id}",
                     "status": "数据不可用" if not tables_ready else "数据缺失",
+                    "current_slot_level": current_slot_level,
+                    "current_enhance_level": current_enhance_level,
                     "current_level": current_level,
-                    "attributes": Counter(),
-                    "attribute_text": "-",
                     "next_level": "-",
                     "item": None,
                     "item_name": "-",
@@ -865,6 +897,11 @@ class datamgr(BaseModel, Component[apiclient]):
                     "universal_item_name": "-",
                     "universal_stock": None,
                     "gap": None,
+                    "ordinary_stocks": {
+                        level: None for level in UNIT_ROLE_MASTERY_LEVELS
+                    },
+                    "reachable_without_universal": "-",
+                    "reachable_with_universal": "-",
                 }
                 if not tables_ready:
                     details.append(detail)
@@ -882,6 +919,14 @@ class datamgr(BaseModel, Component[apiclient]):
                 mastery_levels = mastery_level.get(mastery_id, {})
                 mastery_items = item_data.get(mastery_id, {})
                 detail["name"] = self._unit_role_mastery_slot_name(mastery_slots, slot_id)
+                detail["ordinary_stocks"] = {
+                    level: (
+                        self.get_inventory((eInventoryType.Item, mastery_items[level].item_id_1))
+                        if level in mastery_items
+                        else None
+                    )
+                    for level in UNIT_ROLE_MASTERY_LEVELS
+                }
 
                 if (
                     not mastery_slots
@@ -903,14 +948,28 @@ class datamgr(BaseModel, Component[apiclient]):
                     details.append(detail)
                     continue
 
-                attributes = self.get_unit_role_mastery_attributes(
-                    mastery_id,
-                    current_slot_level,
-                    current_enhance_level,
-                    enhance_data,
+                detail["reachable_without_universal"] = self.format_unit_role_mastery_level(
+                    self.get_unit_role_mastery_reachable_level(
+                        mastery_id,
+                        current_slot_level,
+                        current_enhance_level,
+                        False,
+                        enhance_data,
+                        mastery_level,
+                        item_data,
+                    )
                 )
-                detail["attributes"] = attributes
-                detail["attribute_text"] = self.format_unit_role_mastery_attributes(attributes)
+                detail["reachable_with_universal"] = self.format_unit_role_mastery_level(
+                    self.get_unit_role_mastery_reachable_level(
+                        mastery_id,
+                        current_slot_level,
+                        current_enhance_level,
+                        True,
+                        enhance_data,
+                        mastery_level,
+                        item_data,
+                    )
+                )
 
                 states = sorted(mastery_enhance)
                 current_index = states.index(current)
@@ -927,16 +986,9 @@ class datamgr(BaseModel, Component[apiclient]):
                     continue
 
                 next_level = states[current_index + 1]
-                if next_level[0] == current_slot_level:
-                    is_adjacent = next_level[1] == current_enhance_level + 1
-                else:
-                    next_slot_levels = [
-                        state[1] for state in states if state[0] == next_level[0]
-                    ]
-                    is_adjacent = (
-                        next_level[0] == current_slot_level + 1
-                        and next_level[1] == min(next_slot_levels)
-                    )
+                is_adjacent = self._is_unit_role_mastery_next_level(
+                    current, next_level, states
+                )
                 if not is_adjacent or next_level[0] not in mastery_slots:
                     details.append(detail)
                     continue
@@ -954,7 +1006,7 @@ class datamgr(BaseModel, Component[apiclient]):
 
                 detail.update(cost)
                 detail["status"] = "可升级"
-                detail["next_level"] = f"{next_level[0]}-{next_level[1]}"
+                detail["next_level"] = f"Lv{next_level[0]}.{next_level[1]}"
                 details.append(detail)
 
         return details

--- a/autopcr/core/datamgr.py
+++ b/autopcr/core/datamgr.py
@@ -16,6 +16,25 @@ from asyncio import Lock
 
 _data_lck = Lock()
 
+UNIT_ROLE_MASTERY_PARAM_NAMES = {
+    1: "生命值",
+    2: "攻击力",
+    3: "物理防御力",
+    4: "魔法防御力",
+    5: "暴击",
+    6: "暴击伤害",
+    7: "造成伤害",
+    8: "异常状态命中",
+    9: "异常状态抵抗",
+    10: "普通攻击",
+    11: "增益效果",
+    12: "减益效果",
+    13: "回复效果",
+    14: "技能值充能",
+}
+
+UNIT_ROLE_MASTERY_UNIVERSAL_ITEM_BASE_ID = 80000
+
 class datamgr(BaseModel, Component[apiclient]):
     ready: bool = False
     settings: IniSetting = None
@@ -686,6 +705,259 @@ class datamgr(BaseModel, Component[apiclient]):
         for role_info in self.unit_role_list:
             msg.append(f"{db.unit_role_type[role_info.unit_role_id].unit_role_name}{self.get_role_level_single(role_info)}")
         return "\n".join(msg)
+
+    def get_unit_role_mastery_attributes(
+        self,
+        mastery_id: int,
+        slot_level: int,
+        enhance_level: int,
+        enhance_data=None,
+    ) -> typing.Counter[int]:
+        if enhance_data is None:
+            enhance_data = db.unit_role_mastery_enhance_data
+        row = enhance_data.get(mastery_id, {}).get((slot_level, enhance_level))
+        attributes = Counter()
+        if not row:
+            return attributes
+
+        for index in range(1, 3):
+            param_type = getattr(row, f"role_param_type_{index}", 0)
+            value = getattr(row, f"enhance_value_{index}", 0)
+            if param_type:
+                attributes[param_type] += value
+        return attributes
+
+    @staticmethod
+    def format_unit_role_mastery_attributes(attributes: typing.Counter[int]) -> str:
+        msg = []
+        for param_type, value in sorted(attributes.items()):
+            name = UNIT_ROLE_MASTERY_PARAM_NAMES.get(param_type, f"未知属性{param_type}")
+            sign = "-" if value < 0 else "+"
+            value = abs(value)
+            # 技能值充能以 0.1 TP 记录，其余精通属性以 0.01% 记录。
+            scale = 10 if param_type == 14 else 100
+            integer, decimal = divmod(value, scale)
+            formatted_value = str(integer)
+            if decimal:
+                precision = 1 if scale == 10 else 2
+                formatted_value += f".{decimal:0{precision}d}".rstrip("0")
+            suffix = "" if param_type == 14 else "%"
+            msg.append(f"{name}{sign}{formatted_value}{suffix}")
+        return "/".join(msg) or "-"
+
+    def get_unit_role_mastery_upgrade_cost(
+        self,
+        mastery_id: int,
+        slot_level: int,
+        enhance_level: int,
+        mastery_level=None,
+        item_data=None,
+    ) -> typing.Optional[Dict[str, typing.Any]]:
+        if mastery_level is None:
+            mastery_level = db.unit_role_mastery_level
+        if item_data is None:
+            item_data = db.unit_role_mastery_item_data
+
+        level = mastery_level.get(mastery_id, {}).get((slot_level, enhance_level))
+        item = item_data.get(mastery_id, {}).get(slot_level)
+        if not level or not item:
+            return None
+
+        token = (eInventoryType.Item, item.item_id_1)
+        universal_token = (
+            eInventoryType.Item,
+            UNIT_ROLE_MASTERY_UNIVERSAL_ITEM_BASE_ID + slot_level,
+        )
+        need = level.num
+        stock = self.get_inventory(token)
+        universal_stock = self.get_inventory(universal_token)
+        return {
+            "item": token,
+            "item_name": db.get_inventory_name_san(token),
+            "need": need,
+            "stock": stock,
+            "universal_item": universal_token,
+            "universal_item_name": db.get_inventory_name_san(universal_token),
+            "universal_stock": universal_stock,
+            "gap": max(need - stock - universal_stock, 0),
+        }
+
+    @staticmethod
+    def _unit_role_mastery_slot_name(slot_data, slot_id: int) -> str:
+        if not slot_data:
+            return f"槽位{slot_id}"
+        name = slot_data[min(slot_data)].name
+        if name.startswith("【") and "】" in name:
+            name = name.split("】", 1)[1]
+        marker = name.rfind("Lv")
+        if marker >= 0 and name[marker + 2:].isdigit():
+            name = name[:marker]
+        return name or f"槽位{slot_id}"
+
+    def get_unit_role_mastery_details(self) -> List[Dict[str, typing.Any]]:
+        role_infos = {
+            role_info.unit_role_id: role_info
+            for role_info in (getattr(self, "unit_role_list", None) or [])
+            if getattr(role_info, "unit_role_id", 0) > 0
+        }
+        try:
+            role_types = db.unit_role_type
+        except Exception:
+            role_types = {}
+
+        tables_ready = True
+        try:
+            mastery_ids = db.unit_role_mastery_id
+            slot_data = db.unit_role_mastery_slot_data
+            enhance_data = db.unit_role_mastery_enhance_data
+            mastery_level = db.unit_role_mastery_level
+            item_data = db.unit_role_mastery_item_data
+        except Exception:
+            tables_ready = False
+            mastery_ids = {}
+            slot_data = {}
+            enhance_data = {}
+            mastery_level = {}
+            item_data = {}
+
+        role_ids = sorted({
+            role_id
+            for role_id in set(role_types) | set(role_infos) | set(mastery_ids)
+            if role_id > 0
+        })
+        details = []
+        for role_id in role_ids:
+            role_type = role_types.get(role_id)
+            role_name = (
+                role_type.unit_role_name
+                if role_type and getattr(role_type, "unit_role_name", None)
+                else f"未知职能({role_id})"
+            )
+            role_info = role_infos.get(role_id)
+            role_mastery_ids = mastery_ids.get(role_id, {})
+
+            for slot_id in range(1, 5):
+                current_slot_level = getattr(role_info, f"slot_level_{slot_id}", None) if role_info else None
+                current_enhance_level = getattr(role_info, f"enhance_level_{slot_id}", None) if role_info else None
+                current_level = (
+                    f"{current_slot_level}-{current_enhance_level}"
+                    if current_slot_level is not None
+                    and current_enhance_level is not None
+                    and current_enhance_level >= 0
+                    else "-"
+                )
+                detail = {
+                    "unit_role_id": role_id,
+                    "role_name": role_name,
+                    "slot_id": slot_id,
+                    "mastery_id": None,
+                    "name": f"槽位{slot_id}",
+                    "status": "数据不可用" if not tables_ready else "数据缺失",
+                    "current_level": current_level,
+                    "attributes": Counter(),
+                    "attribute_text": "-",
+                    "next_level": "-",
+                    "item": None,
+                    "item_name": "-",
+                    "need": None,
+                    "stock": None,
+                    "universal_item": None,
+                    "universal_item_name": "-",
+                    "universal_stock": None,
+                    "gap": None,
+                }
+                if not tables_ready:
+                    details.append(detail)
+                    continue
+
+                mastery = role_mastery_ids.get(slot_id)
+                if not mastery:
+                    details.append(detail)
+                    continue
+
+                mastery_id = mastery.mastery_id
+                detail["mastery_id"] = mastery_id
+                mastery_slots = slot_data.get(mastery_id, {})
+                mastery_enhance = enhance_data.get(mastery_id, {})
+                mastery_levels = mastery_level.get(mastery_id, {})
+                mastery_items = item_data.get(mastery_id, {})
+                detail["name"] = self._unit_role_mastery_slot_name(mastery_slots, slot_id)
+
+                if (
+                    not mastery_slots
+                    or not mastery_enhance
+                    or not mastery_levels
+                    or not mastery_items
+                ):
+                    details.append(detail)
+                    continue
+
+                if role_info is None or current_enhance_level is None or current_enhance_level < 0:
+                    detail["status"] = "未解锁"
+                    details.append(detail)
+                    continue
+
+                current = (current_slot_level, current_enhance_level)
+                current_enhance = mastery_enhance.get(current)
+                if current_slot_level not in mastery_slots or not current_enhance:
+                    details.append(detail)
+                    continue
+
+                attributes = self.get_unit_role_mastery_attributes(
+                    mastery_id,
+                    current_slot_level,
+                    current_enhance_level,
+                    enhance_data,
+                )
+                detail["attributes"] = attributes
+                detail["attribute_text"] = self.format_unit_role_mastery_attributes(attributes)
+
+                states = sorted(mastery_enhance)
+                current_index = states.index(current)
+                if current_index == len(states) - 1:
+                    is_complete_max = (
+                        current_slot_level == max(mastery_slots)
+                        and current in mastery_levels
+                        and current_slot_level in mastery_items
+                        and set(mastery_enhance) == set(mastery_levels)
+                        and set(mastery_slots) == set(mastery_items)
+                    )
+                    detail["status"] = "满级" if is_complete_max else "数据缺失"
+                    details.append(detail)
+                    continue
+
+                next_level = states[current_index + 1]
+                if next_level[0] == current_slot_level:
+                    is_adjacent = next_level[1] == current_enhance_level + 1
+                else:
+                    next_slot_levels = [
+                        state[1] for state in states if state[0] == next_level[0]
+                    ]
+                    is_adjacent = (
+                        next_level[0] == current_slot_level + 1
+                        and next_level[1] == min(next_slot_levels)
+                    )
+                if not is_adjacent or next_level[0] not in mastery_slots:
+                    details.append(detail)
+                    continue
+
+                cost = self.get_unit_role_mastery_upgrade_cost(
+                    mastery_id,
+                    current_slot_level,
+                    current_enhance_level,
+                    mastery_level,
+                    item_data,
+                )
+                if not cost:
+                    details.append(detail)
+                    continue
+
+                detail.update(cost)
+                detail["status"] = "可升级"
+                detail["next_level"] = f"{next_level[0]}-{next_level[1]}"
+                details.append(detail)
+
+        return details
 
     def get_talent_skill_info(self) -> str:
         page = 0 if not self.princess_knight_info.talent_skill_last_enhanced_page_node_list else db.talent_skill_node[self.princess_knight_info.talent_skill_last_enhanced_page_node_list[0].node_id].page_num

--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -650,6 +650,72 @@ class database():
             )
 
     @lazy_property
+    def unit_role_mastery_id(self) -> Dict[int, Dict[int, UnitRoleMasteryId]]:
+        with self.dbmgr.session() as db:
+            return (
+                UnitRoleMasteryId.query(db)
+                .group_by(lambda x: x.unit_role_id)
+                .to_dict(
+                    lambda x: x.key,
+                    lambda x: x.to_dict(lambda x: x.slot_id, lambda x: x),
+                )
+            )
+
+    @lazy_property
+    def unit_role_mastery_slot_data(self) -> Dict[int, Dict[int, UnitRoleMasterySlotDatum]]:
+        with self.dbmgr.session() as db:
+            return (
+                UnitRoleMasterySlotDatum.query(db)
+                .group_by(lambda x: x.mastery_id)
+                .to_dict(
+                    lambda x: x.key,
+                    lambda x: x.to_dict(lambda x: x.slot_level, lambda x: x),
+                )
+            )
+
+    @lazy_property
+    def unit_role_mastery_enhance_data(self) -> Dict[int, Dict[Tuple[int, int], UnitRoleMasteryEnhanceDatum]]:
+        with self.dbmgr.session() as db:
+            return (
+                UnitRoleMasteryEnhanceDatum.query(db)
+                .group_by(lambda x: x.mastery_id)
+                .to_dict(
+                    lambda x: x.key,
+                    lambda x: x.to_dict(
+                        lambda x: (x.slot_level, x.enhance_level),
+                        lambda x: x,
+                    ),
+                )
+            )
+
+    @lazy_property
+    def unit_role_mastery_level(self) -> Dict[int, Dict[Tuple[int, int], UnitRoleMasteryLevel]]:
+        with self.dbmgr.session() as db:
+            return (
+                UnitRoleMasteryLevel.query(db)
+                .group_by(lambda x: x.mastery_id)
+                .to_dict(
+                    lambda x: x.key,
+                    lambda x: x.to_dict(
+                        lambda x: (x.slot_level, x.enhance_level),
+                        lambda x: x,
+                    ),
+                )
+            )
+
+    @lazy_property
+    def unit_role_mastery_item_data(self) -> Dict[int, Dict[int, UnitRoleMasteryItemDatum]]:
+        with self.dbmgr.session() as db:
+            return (
+                UnitRoleMasteryItemDatum.query(db)
+                .group_by(lambda x: x.mastery_id)
+                .to_dict(
+                    lambda x: x.key,
+                    lambda x: x.to_dict(lambda x: x.slot_level, lambda x: x),
+                )
+            )
+
+    @lazy_property
     def unique_equipment_enhance_data(self) -> Dict[int, Dict[int, UniqueEquipmentEnhanceDatum]]:
         with self.dbmgr.session() as db:
             return (

--- a/autopcr/module/modules/__init__.py
+++ b/autopcr/module/modules/__init__.py
@@ -208,6 +208,7 @@ tool_modules = ModuleList(
         ex_equip_power_maximun,
         set_my_party2,
         find_talent_quest,
+        find_unit_role_mastery,
         find_clan_talent_quest,
         # return_jewel,
         # cook_pudding,

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -110,7 +110,7 @@ class find_clan_talent_quest(Module):
             self._log(member_progress)
             self._table(data)
 
-@description('查看各职能的四个精通槽位、当前属性和下一级材料，普通碎片与万能碎片分开显示，不会进行强化')
+@description('查看各职能的四个精通槽位、当前属性和下一级碎片，普通碎片与万能碎片分开显示，不会进行强化')
 @notlogin(check_data=True)
 @name('查职能精通')
 class find_unit_role_mastery(Module):
@@ -121,7 +121,6 @@ class find_unit_role_mastery(Module):
         '状态',
         '当前等级',
         '属性',
-        '下一级材料',
         '需要',
         '普通碎片',
         '万能碎片',
@@ -155,7 +154,6 @@ class find_unit_role_mastery(Module):
                 '状态': detail['status'],
                 '当前等级': detail['current_level'],
                 '属性': detail['attribute_text'],
-                '下一级材料': detail['item_name'],
                 '需要': detail['need'] if detail['need'] is not None else '-',
                 '普通碎片': detail['stock'] if detail['stock'] is not None else '-',
                 '万能碎片': detail['universal_stock'] if detail['universal_stock'] is not None else '-',

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -110,22 +110,81 @@ class find_clan_talent_quest(Module):
             self._log(member_progress)
             self._table(data)
 
-@description('查看各职能的四个精通槽位、当前属性和下一级碎片，普通碎片与万能碎片分开显示，不会进行强化')
+@description('查看并导出各职能精通槽位的完整库存数据和最高可达等级，不会进行强化')
 @notlogin(check_data=True)
 @name('查职能精通')
 class find_unit_role_mastery(Module):
+    EXPORT_SCHEMA_VERSION = 1
     HEADERS = [
-        '职能',
-        '槽位',
-        '名称',
+        '格式版本',
+        '玩家ID',
+        '玩家名',
+        '公会ID',
+        '主数据库版本',
+        '数据完整',
+        '职能ID',
+        '职能名称',
+        '槽位ID',
+        '精通ID',
+        '精通名称',
+        '是否解锁',
         '状态',
+        '当前阶段',
+        '当前强化等级',
         '当前等级',
-        '属性',
-        '需要',
-        '普通碎片',
-        '万能碎片',
-        '缺口',
+        '普通T1',
+        '普通T2',
+        '普通T3',
+        '普通T4',
+        '普通T5',
+        '万能T1',
+        '万能T2',
+        '万能T3',
+        '万能T4',
+        '万能T5',
+        '仅普通可达',
+        '含万能单项可达',
     ]
+
+    def _build_row(
+        self,
+        client: pcrclient,
+        detail: Dict,
+        universal_stocks: Dict[int, int],
+        complete: bool,
+    ) -> Dict:
+        unlocked = (
+            detail['current_enhance_level'] is not None
+            and detail['current_enhance_level'] >= 0
+        )
+        return {
+            '格式版本': self.EXPORT_SCHEMA_VERSION,
+            '玩家ID': str(client.data.uid),
+            '玩家名': client.data.user_name or '',
+            '公会ID': str(client.data.clan) if client.data.clan else '',
+            '主数据库版本': getattr(getattr(db, 'dbmgr', None), 'ver', '') or '',
+            '数据完整': '是' if complete else '否',
+            '职能ID': detail['unit_role_id'],
+            '职能名称': detail['role_name'],
+            '槽位ID': detail['slot_id'],
+            '精通ID': detail['mastery_id'],
+            '精通名称': detail['name'],
+            '是否解锁': '是' if unlocked else '否',
+            '状态': detail['status'],
+            '当前阶段': detail['current_slot_level'] if unlocked else None,
+            '当前强化等级': detail['current_enhance_level'] if unlocked else None,
+            '当前等级': detail['current_level'],
+            **{
+                f'普通T{level}': detail['ordinary_stocks'][level]
+                for level in range(1, 6)
+            },
+            **{
+                f'万能T{level}': universal_stocks[level]
+                for level in range(1, 6)
+            },
+            '仅普通可达': detail['reachable_without_universal'],
+            '含万能单项可达': detail['reachable_with_universal'],
+        }
 
     async def do_task(self, client: pcrclient):
         details = client.data.get_unit_role_mastery_details()
@@ -133,29 +192,23 @@ class find_unit_role_mastery(Module):
 
         if not details:
             self._warn('未找到职能精通数据，请登录刷新缓存或更新主数据库')
-            for slot_id in range(1, 5):
-                row = {header: '-' for header in self.HEADERS}
-                row['槽位'] = slot_id
-                row['状态'] = '数据不可用'
-                self._table(row)
             return
 
         if not (getattr(client.data, 'unit_role_list', None) or []):
             self._log('缓存中暂无已解锁职能；以下槽位按未解锁展示')
-        if any(detail['status'] in ('数据不可用', '数据缺失') for detail in details):
+        complete = not any(
+            detail['status'] in ('数据不可用', '数据缺失')
+            for detail in details
+        )
+        if not complete:
             self._warn('部分职能精通主数据不可用，请更新主数据库后重试')
-        self._log('缺口按普通碎片与万能碎片的合计库存计算；万能碎片由同等级槽位共享')
+        self._log('普通与万能碎片按 T1-T5 分列；含万能可达为各槽位独立投入的单项上限')
 
+        universal_stocks = client.data.get_unit_role_mastery_universal_stocks()
         for detail in details:
-            self._table({
-                '职能': detail['role_name'],
-                '槽位': detail['slot_id'],
-                '名称': detail['name'],
-                '状态': detail['status'],
-                '当前等级': detail['current_level'],
-                '属性': detail['attribute_text'],
-                '需要': detail['need'] if detail['need'] is not None else '-',
-                '普通碎片': detail['stock'] if detail['stock'] is not None else '-',
-                '万能碎片': detail['universal_stock'] if detail['universal_stock'] is not None else '-',
-                '缺口': detail['gap'] if detail['gap'] is not None else '-',
-            })
+            self._table(self._build_row(
+                client,
+                detail,
+                universal_stocks,
+                complete,
+            ))

--- a/autopcr/module/modules/talent.py
+++ b/autopcr/module/modules/talent.py
@@ -109,3 +109,55 @@ class find_clan_talent_quest(Module):
             data['顶关未通'] = "√" if flag else ""
             self._log(member_progress)
             self._table(data)
+
+@description('查看各职能的四个精通槽位、当前属性和下一级材料，普通碎片与万能碎片分开显示，不会进行强化')
+@notlogin(check_data=True)
+@name('查职能精通')
+class find_unit_role_mastery(Module):
+    HEADERS = [
+        '职能',
+        '槽位',
+        '名称',
+        '状态',
+        '当前等级',
+        '属性',
+        '下一级材料',
+        '需要',
+        '普通碎片',
+        '万能碎片',
+        '缺口',
+    ]
+
+    async def do_task(self, client: pcrclient):
+        details = client.data.get_unit_role_mastery_details()
+        self._table_header(self.HEADERS.copy())
+
+        if not details:
+            self._warn('未找到职能精通数据，请登录刷新缓存或更新主数据库')
+            for slot_id in range(1, 5):
+                row = {header: '-' for header in self.HEADERS}
+                row['槽位'] = slot_id
+                row['状态'] = '数据不可用'
+                self._table(row)
+            return
+
+        if not (getattr(client.data, 'unit_role_list', None) or []):
+            self._log('缓存中暂无已解锁职能；以下槽位按未解锁展示')
+        if any(detail['status'] in ('数据不可用', '数据缺失') for detail in details):
+            self._warn('部分职能精通主数据不可用，请更新主数据库后重试')
+        self._log('缺口按普通碎片与万能碎片的合计库存计算；万能碎片由同等级槽位共享')
+
+        for detail in details:
+            self._table({
+                '职能': detail['role_name'],
+                '槽位': detail['slot_id'],
+                '名称': detail['name'],
+                '状态': detail['status'],
+                '当前等级': detail['current_level'],
+                '属性': detail['attribute_text'],
+                '下一级材料': detail['item_name'],
+                '需要': detail['need'] if detail['need'] is not None else '-',
+                '普通碎片': detail['stock'] if detail['stock'] is not None else '-',
+                '万能碎片': detail['universal_stock'] if detail['universal_stock'] is not None else '-',
+                '缺口': detail['gap'] if detail['gap'] is not None else '-',
+            })


### PR DESCRIPTION
## 背景

目前项目只能查看职能等级，无法直接查询各职能精通槽位的碎片库存、升级消耗及最高可达等级。

本 PR 新增“查职能精通”功能，并将普通精通碎片与万能精通碎片分开统计，方便进行养成规划和数据导出。

## 主要改动

- 增加职能精通相关主数据库索引
- 查询各职能的 4 个精通槽位
- 展示槽位当前阶段、强化等级和状态
- 分别统计 T1～T5 普通精通碎片库存
- 分别统计 T1～T5 万能精通碎片库存
- 计算仅使用普通碎片时的最高可达等级
- 计算投入万能碎片时各槽位的单项最高可达等级
- 增加玩家、数据库版本及数据完整性字段
- 将“查职能精通”注册至工具模块

## 行为说明

- 本功能只读取缓存数据，不会执行强化
- “仅普通可达”只计算对应槽位的普通碎片
- “含万能单项可达”表示将万能碎片独立投入当前槽位时的最高等级
- 不会在多个槽位之间重复分配或规划万能碎片
- 主数据库缺少相关表或记录时，会显示“数据不可用”或“数据缺失”
- 未解锁的职能或槽位会单独标记，不影响其他数据导出


## 影响范围

本 PR 主要修改以下模块：

- `autopcr/core/datamgr.py`
- `autopcr/db/database.py`
- `autopcr/module/modules/talent.py`
- `autopcr/module/modules/__init__.py`

不修改现有强化流程、登录流程及其他日常任务逻辑。

## 兼容性

对于尚未包含职能精通数据的旧版主数据库，功能会返回数据不可用提示，不会影响其他模块运行。