### PR TITLE
feat: 半月刊日程字段化，新增公开只读 /schedule 端点

### DIFF
--- a/autopcr/db/database.py
+++ b/autopcr/db/database.py
@@ -2512,6 +2512,76 @@ class database():
         id_to = self.campaign_beginner_data[beginner_id].id_to
         return id_from <= quest_id and quest_id <= id_to
 
+    def schedule_entries(self) -> List[dict]:
+        """字段化全部日程（纯静态红标数据，不依赖账号/登录）。半月刊 module 与网站 API 共用此单一来源。
+        每条：{key, category, start_time, end_time, description}
+        - key: 稳定唯一标识（"类别:行主键"，hatsune+seven 同 event_id 时加 #序号），通知侧用它做已读去重
+        - category: 语义类别（公会战/特别地下城/庆典/活动/...），调用方按需过滤
+        - description: 与半月刊渲染文本一致的展示文案；扭蛋 fes 池带 fes| 前缀（渲染侧需剥离，见 half_schedule.do_task）
+        """
+        from ..module.modules.nologin import (
+            ClanBattlePeriod, SecretDungeonSchedule, GachaDatum, CampaignSchedule,
+            CampaignFreegacha, HatsuneSchedule, TowerSchedule, TdfSchedule,
+            ColosseumScheduleData, DomeScheduleData, AbyssSchedule, CaravanSchedule,
+            CharaFortuneSchedule, LoginBonusDatum, SeasonpassFoundation,
+        )
+
+        # (来源表, 工厂)；与半月刊原 schedule_sources 清单一致（顺序即渲染组内顺序）
+        sources = [
+            (self.clan_battle_period, lambda x: ClanBattlePeriod(x.start_time, x.end_time, "公会战")),
+            (self.clan_battle_period, lambda x: ClanBattlePeriod(x.result_start, x.result_end, "公会战排名公示")),
+            (self.secret_dungeon_schedule, lambda x: SecretDungeonSchedule(x.start_time, x.end_time, "特别地下城")),
+            (self.seasonpass_foundation, lambda x: SeasonpassFoundation(x.name, x.start_time, x.end_time, "季卡")),
+            (self.gacha_data, lambda x: GachaDatum(x.gacha_id, x.exchange_id, x.start_time, x.end_time, "扭蛋")),
+            (self.campaign_schedule, lambda x: CampaignSchedule(x.id, x.campaign_category, x.value, x.start_time, x.end_time, "庆典")),
+            (self.campaign_free_gacha, lambda x: CampaignFreegacha(x.campaign_id, x.start_time, x.end_time, "免费十连")),
+            (self.hatsune_schedule, lambda x: HatsuneSchedule(x.event_id, x.start_time, x.end_time, "活动")),
+            (self.seven_schedule, lambda x: HatsuneSchedule(x.event_id, x.start_time, x.end_time, "活动")),
+            (self.tower_schedule, lambda x: TowerSchedule(x.start_time, x.end_time, "露娜塔")),
+            (self.tdf_schedule, lambda x: TdfSchedule(x.start_time, x.end_time, "次元断层")),
+            (self.chara_fortune_schedule, lambda x: CharaFortuneSchedule(x.name, x.start_time, x.end_time, "赛马")),
+            (self.login_bonus_data, lambda x: LoginBonusDatum(x.name, x.start_time, x.end_time, "登录奖励")),
+            (self.colosseum_schedule_data, lambda x: ColosseumScheduleData(x.start_time, x.end_time, "斗技场")),
+            (self.caravan_schedule, lambda x: CaravanSchedule(x.season_id, x.start_time, x.end_time, "驾车游")),
+            (self.dome_schedule_data, lambda x: DomeScheduleData(x.start_time, x.end_time, "新斗技场")),
+            (self.abyss_schedule, lambda x: AbyssSchedule(x.talent_id, x.start_time, x.end_time, "深渊讨伐战")),
+        ]
+
+        entries: List[dict] = []
+        counters: Counter = Counter()
+        order = 0
+        for table, factory in sources:
+            # key 生成必须在 enabled 过滤之前：行从 enabled 转 disabled 时，后续行 #n 不得漂移
+            for row_key, row in table.items():
+                schedule = factory(row)
+                # key = 语义类别 + 行主键（dict 键即行主键，不取 name 等文本列——防改名/含分隔符导致 key 漂移）
+                base_key = ':'.join([schedule.description, str(row_key)])
+                counters[base_key] += 1
+                stable_key = base_key if counters[base_key] == 1 else base_key + '#' + str(counters[base_key])
+                if not schedule.enabled:
+                    continue
+                desc = schedule.get_description()
+                # 扭蛋条目：官方池名 gacha_name 含 フェス/FES 判定为 fes 池，织入标记供通知侧折叠（只留第一人 + fes扭蛋）；
+                # 渲染侧（half_schedule.do_task）负责剥离前缀，保证半月刊输出 parity
+                if schedule.description == "扭蛋":
+                    gacha_name = row.gacha_name or ''
+                    if ('フェス' in gacha_name) or ('FES' in gacha_name.upper()):  # 宽松子串匹配是有意的
+                        desc = 'fes|' + desc
+                entries.append({
+                    'key': stable_key,
+                    'category': schedule.description,
+                    'start_time': self.format_date(self.parse_time(schedule.start_time)),
+                    'end_time': self.format_date(self.parse_time(schedule.end_time)),
+                    'description': desc,
+                    '_order': order,
+                })
+                order += 1
+        # 排序与半月刊旧实现一致：(start, end, 源清单顺序)——不得用 key 码点序，否则组内顺序漂移破坏 parity
+        entries.sort(key=lambda e: (e['start_time'], e['end_time'], e['_order']))
+        for e in entries:
+            e.pop('_order')
+        return entries
+
     def is_clan_battle_time(self, now: Union[None, datetime.datetime] = None) -> bool:
         schedule = [(db.parse_time(schedule.start_time), db.parse_time(schedule.end_time)) 
                     for schedule in self.clan_battle_period.values()]

--- a/autopcr/http_server/httpserver.py
+++ b/autopcr/http_server/httpserver.py
@@ -13,6 +13,7 @@ from quart_rate_limiter import RateLimiter, rate_limit, RateLimitExceeded
 
 from .validator import validate_dict, ValidateInfo, validate_ok_dict, enable_manual_validator
 from ..constants import CACHE_DIR, ALLOW_REGISTER, SUPERUSER
+from ..db.database import db
 from ..module.accountmgr import Account, AccountManager, instance as usermgr, AccountException, UserData, \
     PermissionLimitedException, UserDisabledException, UserException
 from ..util.draw import instance as drawer
@@ -186,6 +187,11 @@ class HttpServer:
             data = (await request.get_json())['accs'].split('\n')
             usermgr.set_clan_battle_forbidden(data)
             return f'设置成功，禁止了{len(data)}个账号', 200
+
+        @self.api.route('/schedule', methods = ["GET"])
+        async def get_schedule():
+            """半月刊结构化日程（字段化，无账号依赖）。网页端通知与本 module 渲染共用数据源。"""
+            return db.schedule_entries(), 200
 
         @self.api.route('/role', methods = ["GET"])
         @HttpServer.login_required()

--- a/autopcr/module/modules/nologin.py
+++ b/autopcr/module/modules/nologin.py
@@ -216,12 +216,13 @@ class half_schedule(Module):
         ]
 
     async def do_task(self, _: pcrclient):
+        # 结构化数据单一来源：db.schedule_entries()（字段化供 API/通知复用），这里只做渲染
         schedules = defaultdict(list)
-        for table, factory in self.schedule_sources():
-            for row in table.values():
-                schedule = factory(row)
-                if schedule.enabled:
-                    schedules[(db.format_date(db.parse_time(schedule.start_time)), db.format_date(db.parse_time(schedule.end_time)))].append(schedule.get_description())
+        for entry in db.schedule_entries():
+            msg = entry['description']
+            if msg.startswith('fes|'):
+                msg = msg[4:]  # 剥离 fes 标记（通知侧契约），半月刊渲染保持 parity
+            schedules[(entry['start_time'], entry['end_time'])].append(msg)
         times = sorted(schedules.keys())
         mirai = False
         for time in times:


### PR DESCRIPTION
- database: 新增 db.schedule_entries()，遍历 17 个日程来源表返回 [{key, category, start_time, end_time, description}]；key 为 类别:行主键（hatsune/seven 同 event_id 加 #序号），排序保持 (start, end, 源清单顺序) 与半月刊渲染逐行一致
- 扭蛋 fes 池（gacha_name 含 フェス/FES）description 织入 fes| 前缀，供网页端通知折叠为「up 首人 fes扭蛋」
- httpserver: 新增 GET /schedule 公开只读路由（无登录依赖）
- nologin: half_schedule.do_task 改为渲染 db.schedule_entries() 单一数据源，渲染时剥离 fes| 前缀保持输出 parity
- 
<img width="860" height="1315" alt="image" src="https://github.com/user-attachments/assets/1d3a50f9-33a7-4ead-88a1-ce42fdd71a25" />

mock下不完全准确的按钮。
该改动是为了配合将要给前端推送的“系统任务栏通知”以及“不上游戏也能快速知道游戏排期”的功能而做的。
另外请求把部分dev版功能移至main。例如邮箱通知同样可以通知到排期。